### PR TITLE
Enhancements for AWS ECR, and allow for a configurable container server port and stripes branch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 .vscode
+.idea
+eureka-cli/misc/folio-keycloak
+eureka-cli/misc/folio-kong

--- a/eureka-cli/README.md
+++ b/eureka-cli/README.md
@@ -53,10 +53,27 @@ env GOOS=windows GOARCH=amd64 go build -o ./bin .
 
 > ./bin/eureka-cli.exe -c ./config.minimal.yaml undeployApplication
 
+### Use the environment
+
 - Test Keycloak authentication on the UI using the created `diku` realm and `diku-login-app` public client
 
 > Open in browser `http://keycloak.eureka:8080/realms/diku/protocol/openid-connect/auth?client_id=diku-login-app&response_type=code&redirect_uri=http://localhost:3000&scope=openid`
 
+- Gateway is available at`localhost:8000` or `api-gateway.eureka:8000`
+- Login and get a token:
+
+```shell
+curl --request POST \
+  --url localhost:8000/authn/login-with-expiry \
+  --header 'Content-Type: application/json' \
+  --header 'X-Okapi-Tenant: diku' \
+  --data '{"username":"diku_admin","password": "admin"}' \
+  --verbose
+```
+
 ### Troubleshooting
 
 - Verify that all shell scripts located under `./misc` folder are saved using the **LF** (Line Feed) line break
+- If you get a SIGKILL when trying to build the stripes container configure Rancher Desktop or other docker env with more RAM
+- If health checks are failing make sure localhost is mapped to host.docker.internal in your /etc/hosts file
+- If using Rancher Desktop on a system that also uses Docker Desktop, you may need to do set `DOCKER_HOST` in your env to where `docker.sock`is

--- a/eureka-cli/cmd/deployApplication.go
+++ b/eureka-cli/cmd/deployApplication.go
@@ -30,15 +30,15 @@ var deployApplicationCmd = &cobra.Command{
 }
 
 func DeployApplication() {
-	DeploySystem()
+	//DeploySystem()
 	DeployManagement()
-	DeployModules()
-	CreateTenants()
-	CreateTenantEntitlements()
-	CreateRoles()
-	AttachCapabilitySets(true)
-	CreateUsers()
-	DeployUi()
+	//DeployModules()
+	//CreateTenants()
+	//CreateTenantEntitlements()
+	//CreateRoles()
+	//AttachCapabilitySets(true)
+	//CreateUsers()
+	//DeployUi()
 }
 
 func init() {

--- a/eureka-cli/cmd/deployApplication.go
+++ b/eureka-cli/cmd/deployApplication.go
@@ -31,8 +31,8 @@ var deployApplicationCmd = &cobra.Command{
 
 func DeployApplication() {
 	//DeploySystem()
-	DeployManagement()
-	//DeployModules()
+	//DeployManagement()
+	DeployModules()
 	//CreateTenants()
 	//CreateTenantEntitlements()
 	//CreateRoles()

--- a/eureka-cli/cmd/deployApplication.go
+++ b/eureka-cli/cmd/deployApplication.go
@@ -30,15 +30,15 @@ var deployApplicationCmd = &cobra.Command{
 }
 
 func DeployApplication() {
-	//DeploySystem()
-	//DeployManagement()
+	DeploySystem()
+	DeployManagement()
 	DeployModules()
-	//CreateTenants()
-	//CreateTenantEntitlements()
-	//CreateRoles()
-	//AttachCapabilitySets(true)
-	//CreateUsers()
-	//DeployUi()
+	CreateTenants()
+	CreateTenantEntitlements()
+	CreateRoles()
+	AttachCapabilitySets(true)
+	CreateUsers()
+	DeployUi()
 }
 
 func init() {

--- a/eureka-cli/cmd/deployManagement.go
+++ b/eureka-cli/cmd/deployManagement.go
@@ -55,8 +55,6 @@ func DeployManagement() {
 	internal.ExtractModuleNameAndVersion(deployManagementCommand, enableDebug, registryModules)
 
 	slog.Info(deployManagementCommand, "### ACQUIRING VAULT ROOT TOKEN ###", "")
-	// TODO on macOS if you're running Rancher Desktop you have to set your docker demon socket such as export DOCKER_HOST="unix:///System/Volumes/Data/Users/<your user>/.rd/docker.sock"
-	// TODO Otherwise the first use of the docker API client will fail here.
 	client := internal.CreateClient(deployManagementCommand)
 	defer client.Close()
 	vaultRootToken := internal.GetRootVaultToken(deployManagementCommand, client)

--- a/eureka-cli/cmd/deployManagement.go
+++ b/eureka-cli/cmd/deployManagement.go
@@ -55,6 +55,8 @@ func DeployManagement() {
 	internal.ExtractModuleNameAndVersion(deployManagementCommand, enableDebug, registryModules)
 
 	slog.Info(deployManagementCommand, "### ACQUIRING VAULT ROOT TOKEN ###", "")
+	// TODO on macOS if you're running Rancher Desktop you have to set your docker demon socket such as export DOCKER_HOST="unix:///System/Volumes/Data/Users/<your user>/.rd/docker.sock"
+	// TODO Otherwise the first use of the docker API client will fail here.
 	client := internal.CreateClient(deployManagementCommand)
 	defer client.Close()
 	vaultRootToken := internal.GetRootVaultToken(deployManagementCommand, client)

--- a/eureka-cli/cmd/deploySystem.go
+++ b/eureka-cli/cmd/deploySystem.go
@@ -46,7 +46,6 @@ func DeploySystem() {
 		internal.RunCommandFromDir(deployManagementCommand, preparedCommand, internal.DockerComposeWorkDir)
 	}
 	slog.Info(deploySystemCommand, "### WAITING FOR SYSTEM TO INITIALIZE ###", "")
-	// TODO Make this configurable via env
 	time.Sleep(15 * time.Second)
 }
 

--- a/eureka-cli/cmd/deploySystem.go
+++ b/eureka-cli/cmd/deploySystem.go
@@ -46,7 +46,8 @@ func DeploySystem() {
 		internal.RunCommandFromDir(deployManagementCommand, preparedCommand, internal.DockerComposeWorkDir)
 	}
 	slog.Info(deploySystemCommand, "### WAITING FOR SYSTEM TO INITIALIZE ###", "")
-	time.Sleep(150 * time.Second)
+	// TODO Make this configurable via env
+	time.Sleep(15 * time.Second)
 }
 
 func init() {

--- a/eureka-cli/cmd/deployUi.go
+++ b/eureka-cli/cmd/deployUi.go
@@ -32,9 +32,7 @@ const (
 	deployUiCommand     string = "Deploy UI"
 	platformCompleteDir string = "platform-complete"
 
-	// TODO Make configurable
-	//branchName plumbing.ReferenceName = "snapshot"
-	branchName plumbing.ReferenceName = "R1-2024"
+	defaultStripesBranch plumbing.ReferenceName = "snapshot"
 )
 
 // deployUiCmd represents the deployUi command
@@ -51,8 +49,10 @@ func DeployUi() {
 	slog.Info(deployUiCommand, "### ACQUIRING KEYCLOAK MASTER ACCESS TOKEN ###", "")
 
 	slog.Info(deployUiCommand, "### CLONING PLATFORM COMPLETE UI FROM A SNAPSHOT BRANCH ###", "")
+	var stripesBranch = internal.GetStripesBranch(deployUiCommand, defaultStripesBranch)
+
 	outputDir := fmt.Sprintf("%s/%s", internal.DockerComposeWorkDir, platformCompleteDir)
-	internal.GitCloneRepository(deployUiCommand, enableDebug, internal.PlatformCompleteRepositoryUrl, branchName, outputDir, false)
+	internal.GitCloneRepository(deployUiCommand, enableDebug, internal.PlatformCompleteRepositoryUrl, stripesBranch, outputDir, false)
 
 	for _, value := range internal.GetTenants(deployUiCommand, enableDebug, false) {
 		mapEntry := value.(map[string]interface{})

--- a/eureka-cli/cmd/redirect.go
+++ b/eureka-cli/cmd/redirect.go
@@ -16,10 +16,9 @@ limitations under the License.
 package cmd
 
 import (
-	"log/slog"
-
 	"github.com/folio-org/eureka-cli/internal"
 	"github.com/spf13/cobra"
+	"log/slog"
 )
 
 const redirectModuleCommand = "Redirect Module"
@@ -43,7 +42,7 @@ var redirectCmd = &cobra.Command{
 // TODO Fix redirectModules to work on host network
 func RedirectModules() {
 	slog.Info(redirectModuleCommand, "### REDIRECT MODULE ###", "")
-	internal.UpdateApplicationModuleDiscovery(redirectModuleCommand, enableDebug, id, location, restore)
+	internal.UpdateApplicationModuleDiscovery(redirectModuleCommand, enableDebug, id, location, restore, internal.DefaultServerPort)
 }
 
 func init() {

--- a/eureka-cli/cmd/undeployApplication.go
+++ b/eureka-cli/cmd/undeployApplication.go
@@ -30,10 +30,10 @@ var undeployApplicationCmd = &cobra.Command{
 }
 
 func UndeployApplication() {
-	UndeployUi()
-	UndeployModules()
+	//UndeployUi()
+	//UndeployModules()
 	UndeployManagement()
-	UndeploySystem()
+	//UndeploySystem()
 }
 
 func init() {

--- a/eureka-cli/cmd/undeployApplication.go
+++ b/eureka-cli/cmd/undeployApplication.go
@@ -30,10 +30,10 @@ var undeployApplicationCmd = &cobra.Command{
 }
 
 func UndeployApplication() {
-	//UndeployUi()
-	//UndeployModules()
+	UndeployUi()
+	UndeployModules()
 	UndeployManagement()
-	//UndeploySystem()
+	UndeploySystem()
 }
 
 func init() {

--- a/eureka-cli/config.minimal.yaml
+++ b/eureka-cli/config.minimal.yaml
@@ -11,8 +11,8 @@ application:
 # Registry
 registry: 
   registry-url: https://folio-registry.dev.folio.org
-  folio-install-json-url: https://raw.githubusercontent.com/folio-org/platform-complete/snapshot/install.json
-  eureka-install-json-url: https://raw.githubusercontent.com/folio-org/platform-complete/snapshot/eureka-platform.json
+  folio-install-json-url: https://raw.githubusercontent.com/folio-org/platform-complete/refs/heads/R1-2024/install.json
+  eureka-install-json-url: https://raw.githubusercontent.com/folio-org/platform-complete/refs/heads/R1-2024/eureka-platform.json
 # Environment
 environment:
   # General

--- a/eureka-cli/config.minimal.yaml
+++ b/eureka-cli/config.minimal.yaml
@@ -1,5 +1,5 @@
 # Profile
-profile: 
+profile:
   name: minimal
 # Application
 application:
@@ -9,10 +9,10 @@ application:
   fetch-descriptors: false
   port-start: 30000
 # Registry
-registry: 
+registry:
   registry-url: https://folio-registry.dev.folio.org
-  folio-install-json-url: https://raw.githubusercontent.com/folio-org/platform-complete/refs/heads/R1-2024/install.json
-  eureka-install-json-url: https://raw.githubusercontent.com/folio-org/platform-complete/refs/heads/R1-2024/eureka-platform.json
+  folio-install-json-url: https://raw.githubusercontent.com/folio-org/platform-complete/snapshot/install.json
+  eureka-install-json-url: https://raw.githubusercontent.com/folio-org/platform-complete/snapshot/eureka-platform.json
 # Environment
 environment:
   # General
@@ -47,7 +47,7 @@ environment:
   MT_URL: http://mgr-tenants.eureka:8081
   AM_CLIENT_URL: http://mgr-applications.eureka:8081
   KONG_ADMIN_URL: http://api-gateway.eureka:8001
-  # Keycloak 
+  # Keycloak
   KC_URL: http://keycloak.eureka:8080
   KC_ADMIN_CLIENT_ID: supersecret
   KC_ADMIN_USERNAME: admin
@@ -62,11 +62,11 @@ environment:
   # Java
   JAVA_OPTIONS: "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005 -XX:MaxRAMPercentage=90.0 -Xms256m -Xmx512m"
 # Files
-files: 
+files:
   module-env: .module.env
   module-descriptors: .module-descriptors.json
 # Resources
-resources: 
+resources:
   kong: http://api-gateway.eureka:8000
   vault: http://vault.eureka:8200
   keycloak: http://keycloak.eureka:8080
@@ -79,31 +79,31 @@ tenants:
   - diku
 # Roles
 roles:
-  Admin: 
+  Admin:
     tenant: diku
-    capability-sets: 
+    capability-sets:
       - all
-  User: 
+  User:
     tenant: diku
     capability-sets:
       - login.manage
       - mod-settings_entries.manage
 # Users
 users:
-  diku_admin: 
+  diku_admin:
     tenant: diku
     password: admin
     last-name: John
     first-name: Doe
-    roles: 
+    roles:
       - Admin
       - User
-  diku_user: 
+  diku_user:
     tenant: diku
     password: user
     last-name: John
     first-name: Smith
-    roles: 
+    roles:
       - User
 # Sidecar module
 sidecar-module:

--- a/eureka-cli/internal/config.go
+++ b/eureka-cli/internal/config.go
@@ -131,7 +131,6 @@ func GetBackendModulesFromConfig(commandName string, backendModulesAnyMap map[st
 			environment  map[string]interface{}
 		)
 
-		//		if value != nil {
 		mapEntry := value.(map[string]interface{})
 
 		if mapEntry[DeployModuleKey] != nil {

--- a/eureka-cli/internal/config.go
+++ b/eureka-cli/internal/config.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"fmt"
+	"github.com/go-git/go-git/v5/plumbing"
 	"log"
 	"log/slog"
 	"os"
@@ -39,8 +40,9 @@ const (
 const (
 	ProfileNameKey string = "profile.name"
 
-	ApplicationKey       string = "application"
-	ApplicationPortStart string = "application.port-start"
+	ApplicationKey           string = "application"
+	ApplicationPortStart     string = "application.port-start"
+	ApplicationStripesBranch string = "application.stripes-branch"
 
 	RegistryUrlKey                  string = "registry.registry-url"
 	RegistryFolioInstallJsonUrlKey  string = "registry.folio-install-json-url"
@@ -289,4 +291,19 @@ func PrepareStripesConfigJson(commandName string, configPath string, tenant stri
 		slog.Error(commandName, "os.WriteFile error", "")
 		panic(err)
 	}
+}
+
+func GetStripesBranch(commandName string, defaultBranch plumbing.ReferenceName) plumbing.ReferenceName {
+	var stripesBranch plumbing.ReferenceName
+
+	if viper.IsSet(ApplicationStripesBranch) {
+		branchStr := viper.GetString(ApplicationStripesBranch)
+		stripesBranch = plumbing.ReferenceName(branchStr)
+	} else {
+		stripesBranch = defaultBranch
+	}
+
+	slog.Info(commandName, fmt.Sprintf("Stripes branch: %s", stripesBranch))
+
+	return stripesBranch
 }

--- a/eureka-cli/internal/config.go
+++ b/eureka-cli/internal/config.go
@@ -299,11 +299,11 @@ func GetStripesBranch(commandName string, defaultBranch plumbing.ReferenceName) 
 	if viper.IsSet(ApplicationStripesBranch) {
 		branchStr := viper.GetString(ApplicationStripesBranch)
 		stripesBranch = plumbing.ReferenceName(branchStr)
+		slog.Info(commandName, fmt.Sprintf("Got stripes branch from config: %s", stripesBranch), "")
 	} else {
 		stripesBranch = defaultBranch
+		slog.Info(commandName, fmt.Sprintf("No stripes branch in config. Using default branch: %s", stripesBranch), "")
 	}
-
-	slog.Info(commandName, fmt.Sprintf("Stripes branch: %s", stripesBranch))
 
 	return stripesBranch
 }

--- a/eureka-cli/internal/config.go
+++ b/eureka-cli/internal/config.go
@@ -17,7 +17,7 @@ const (
 	NetworkId            string = "eureka"
 	DockerInternalUrl    string = "http://host.docker.internal:%d%s"
 	HostIp               string = "0.0.0.0"
-	ServerPort           string = "8081"
+	ServerPort           string = "8082"
 	DebugPort            string = "5005"
 
 	PlatformCompleteUrl           string = "http://localhost:3000"

--- a/eureka-cli/internal/config.go
+++ b/eureka-cli/internal/config.go
@@ -19,7 +19,7 @@ const (
 	NetworkId            string = "eureka"
 	DockerInternalUrl    string = "http://host.docker.internal:%d%s"
 	HostIp               string = "0.0.0.0"
-	ServerPort           string = "8082"
+	DefaultServerPort    string = "8081"
 	DebugPort            string = "5005"
 
 	PlatformCompleteUrl           string = "http://localhost:3000"
@@ -73,7 +73,7 @@ const (
 	DeployModuleKey string = "deploy-module"
 	VersionKey      string = "version"
 	PortKey         string = "port"
-	PortKeyInternal string = "port-internal"
+	PortKeyServer   string = "port-server"
 	SidecarKey      string = "sidecar"
 	ModuleEnvKey    string = "environment"
 )
@@ -128,7 +128,7 @@ func GetBackendModulesFromConfig(commandName string, backendModulesAnyMap map[st
 			deployModule bool = true
 			version      *string
 			port         *int
-			portInternal *int
+			portServer   *int
 			sidecar      *bool
 			environment  map[string]interface{}
 		)
@@ -158,13 +158,13 @@ func GetBackendModulesFromConfig(commandName string, backendModulesAnyMap map[st
 			port = &PortIndex
 		}
 
-		if mapEntry[PortKeyInternal] != nil {
-			slog.Info("Assigning port internal")
-			portInternalValue := mapEntry[PortKeyInternal].(int)
-			portInternal = &portInternalValue
+		if mapEntry[PortKeyServer] != nil {
+			portServerValue := mapEntry[PortKeyServer].(int)
+			portServer = &portServerValue
 		} else {
-			portInternalValue := 8081
-			portInternal = &portInternalValue
+			p, _ := strconv.Atoi(DefaultServerPort)
+			portServerValue := p
+			portServer = &portServerValue
 		}
 
 		if mapEntry[SidecarKey] != nil {
@@ -182,9 +182,9 @@ func GetBackendModulesFromConfig(commandName string, backendModulesAnyMap map[st
 		}
 
 		if sidecar != nil && *sidecar {
-			backendModulesMap[name] = *NewBackendModuleAndSidecar(deployModule, name, version, *port, *portInternal, *sidecar, environment)
+			backendModulesMap[name] = *NewBackendModuleAndSidecar(deployModule, name, version, *port, *portServer, *sidecar, environment)
 		} else {
-			backendModulesMap[name] = *NewBackendModule(name, *port, *portInternal, environment)
+			backendModulesMap[name] = *NewBackendModule(name, *port, *portServer, environment)
 		}
 
 		moduleInfo := name

--- a/eureka-cli/internal/environment.go
+++ b/eureka-cli/internal/environment.go
@@ -50,12 +50,12 @@ func AppendModuleEnvironment(extraEnvironmentMap map[string]interface{}, environ
 	return environment
 }
 
-func AppendSidecarEnvironment(environment []string, module *RegistryModule) []string {
+func AppendSidecarEnvironment(environment []string, module *RegistryModule, portServer string) []string {
 	extraEnvironment := []string{fmt.Sprintf("MODULE_NAME=%s", module.Name),
 		fmt.Sprintf("MODULE_VERSION=%s", *module.Version),
-		fmt.Sprintf("MODULE_URL=http://%s.eureka:%s", module.Name, ServerPort),
+		fmt.Sprintf("MODULE_URL=http://%s.eureka:%s", module.Name, portServer),
 		fmt.Sprintf("SIDECAR_NAME=%s", module.SidecarName),
-		fmt.Sprintf("SIDECAR_URL=http://%s.eureka:%s", module.SidecarName, ServerPort),
+		fmt.Sprintf("SIDECAR_URL=http://%s.eureka:%s", module.SidecarName, portServer),
 		fmt.Sprintf("MOD_USERS_KEYCLOAK_URL=%s", viper.GetString(ResourcesModUsersKeycloakKey)),
 		"SIDECAR_FORWARD_UNKNOWN_REQUESTS='true'",
 		fmt.Sprintf("SIDECAR_FORWARD_UNKNOWN_REQUESTS_DESTINATION=%s", viper.GetString(ResourcesKongKey)),

--- a/eureka-cli/internal/management.go
+++ b/eureka-cli/internal/management.go
@@ -71,6 +71,7 @@ func PerformModuleHealthcheck(commandName string, enableDebug bool, waitMutex *s
 	healthcheckAttempts := HealtcheckMaxAttempts
 	for {
 		time.Sleep(HealthcheckDefaultDuration)
+		slog.Info(commandName, fmt.Sprintf("After sleep at %s for %d", requestUrl, HealthcheckDefaultDuration), "")
 
 		isHealthyVertxContainer := false
 		actuatorHealthStr := DoGetDecodeReturnString(commandName, requestUrl, enableDebug, false, map[string]string{})

--- a/eureka-cli/internal/management.go
+++ b/eureka-cli/internal/management.go
@@ -367,7 +367,8 @@ func RemoveTenantEntitlements(commandName string, enableDebug bool, panicOnError
 
 // TODO Add depCheck=false flag
 func CreateTenantEntitlement(commandName string, enableDebug bool) {
-	requestUrl := fmt.Sprintf(DockerInternalUrl, TenantEntitlementsPort, "/entitlements?purgeOnRollback=true&ignoreErrors=false&tenantParameters=loadReference=false,loadSample=false")
+	//requestUrl := fmt.Sprintf(DockerInternalUrl, TenantEntitlementsPort, "/entitlements?purgeOnRollback=true&ignoreErrors=false&tenantParameters=loadReference=false,loadSample=false")
+	requestUrl := fmt.Sprintf(DockerInternalUrl, TenantEntitlementsPort, "/entitlements?depCheck=false&purgeOnRollback=true&ignoreErrors=true&tenantParameters=loadReference=false,loadSample=false")
 	applicationMap := viper.GetStringMap(ApplicationKey)
 	applicationName := applicationMap["name"].(string)
 	applicationVersion := applicationMap["version"].(string)

--- a/eureka-cli/internal/management.go
+++ b/eureka-cli/internal/management.go
@@ -71,7 +71,6 @@ func PerformModuleHealthcheck(commandName string, enableDebug bool, waitMutex *s
 	healthcheckAttempts := HealtcheckMaxAttempts
 	for {
 		time.Sleep(HealthcheckDefaultDuration)
-		slog.Info(commandName, fmt.Sprintf("After sleep at %s for %d", requestUrl, HealthcheckDefaultDuration), "")
 
 		isHealthyVertxContainer := false
 		actuatorHealthStr := DoGetDecodeReturnString(commandName, requestUrl, enableDebug, false, map[string]string{})

--- a/eureka-cli/internal/management.go
+++ b/eureka-cli/internal/management.go
@@ -367,8 +367,7 @@ func RemoveTenantEntitlements(commandName string, enableDebug bool, panicOnError
 
 // TODO Add depCheck=false flag
 func CreateTenantEntitlement(commandName string, enableDebug bool) {
-	//requestUrl := fmt.Sprintf(DockerInternalUrl, TenantEntitlementsPort, "/entitlements?purgeOnRollback=true&ignoreErrors=false&tenantParameters=loadReference=false,loadSample=false")
-	requestUrl := fmt.Sprintf(DockerInternalUrl, TenantEntitlementsPort, "/entitlements?depCheck=false&purgeOnRollback=true&ignoreErrors=true&tenantParameters=loadReference=false,loadSample=false")
+	requestUrl := fmt.Sprintf(DockerInternalUrl, TenantEntitlementsPort, "/entitlements?purgeOnRollback=true&ignoreErrors=false&tenantParameters=loadReference=false,loadSample=false")
 	applicationMap := viper.GetStringMap(ApplicationKey)
 	applicationName := applicationMap["name"].(string)
 	applicationVersion := applicationMap["version"].(string)

--- a/eureka-cli/internal/module.go
+++ b/eureka-cli/internal/module.go
@@ -381,7 +381,7 @@ func DeployModules(commandName string, client *client.Client, dto *DeployModules
 	var sidecarImage string
 	if sidecarImage == "" {
 		sidecarId := fmt.Sprintf("%s:%s", sidecarModule["image"], sidecarModule["version"])
-		sidecarImage = fmt.Sprintf("%s/%s", DetermineImageRegistryNamespace(sidecarModule["version"].(string)), sidecarId)
+		sidecarImage = fmt.Sprintf("%s/%s", GetImageRegistryNamespace(sidecarModule["version"].(string)), sidecarId)
 	}
 
 	resourceUrlVault := viper.GetString(ResourcesVaultKey)
@@ -407,14 +407,13 @@ func DeployModules(commandName string, client *client.Client, dto *DeployModules
 				continue
 			}
 
-			image := fmt.Sprintf("%s/%s:%s", DetermineImageRegistryNamespace(*module.Version), module.Name, *module.Version)
+			image := fmt.Sprintf("%s/%s:%s", GetImageRegistryNamespace(*module.Version), module.Name, *module.Version)
 
 			var combinedModuleEnvironment []string
 			combinedModuleEnvironment = append(combinedModuleEnvironment, dto.GlobalEnvironment...)
 			combinedModuleEnvironment = AppendModuleEnvironment(backendModule.ModuleEnvironment, combinedModuleEnvironment)
 			combinedModuleEnvironment = AppendVaultEnvironment(combinedModuleEnvironment, dto.VaultRootToken, resourceUrlVault)
 
-			// TODO Make calling this configurable such that if the env var isn't present pass an empty authToken string.
 			authToken := GetEurekaRegistryAuthToken(commandName)
 
 			slog.Info(commandName, fmt.Sprint("Deploying image: ", image, "Auth Token: ", len(authToken)), "")
@@ -447,18 +446,4 @@ func DeployModules(commandName string, client *client.Client, dto *DeployModules
 	}
 
 	return deployedModules
-}
-
-// TODO fix this
-func DetermineImageRegistryNamespace(version string) string {
-	var registryNamespace string
-	//if strings.Contains(version, "SNAPSHOT") {
-	//	registryNamespace = SnapshotRegistry
-	//} else {
-	//	registryNamespace = ReleaseRegistry
-	//}
-
-	registryNamespace = os.Getenv("AWS_ECR_FOLIO_REPO")
-
-	return registryNamespace
 }

--- a/eureka-cli/internal/module.go
+++ b/eureka-cli/internal/module.go
@@ -400,6 +400,9 @@ func DeployModules(commandName string, client *client.Client, dto *DeployModules
 
 			image := fmt.Sprintf("%s/%s:%s", DetermineImageRegistryNamespace(*module.Version), module.Name, *module.Version)
 
+			// TODO Strip out snapshot from the string
+			image = StripSnapshotFromImage(image)
+
 			var combinedModuleEnvironment []string
 			combinedModuleEnvironment = append(combinedModuleEnvironment, dto.GlobalEnvironment...)
 			combinedModuleEnvironment = AppendModuleEnvironment(backendModule.ModuleEnvironment, combinedModuleEnvironment)
@@ -409,7 +412,7 @@ func DeployModules(commandName string, client *client.Client, dto *DeployModules
 			// TODO and pass it into a param here to populate RegistryAuth
 			authToken := GetEurekaRegistryAuthToken(commandName)
 
-			slog.Info(commandName, fmt.Sprint("image: ", image, " Token: ", authToken))
+			slog.Info(commandName, fmt.Sprint("image: ", image, " Token: ", len(authToken)), "")
 
 			deployModuleDto := NewDeployModuleDto(module.Name, *module.Version, image, combinedModuleEnvironment, backendModule, networkConfig, authToken)
 
@@ -450,4 +453,12 @@ func DetermineImageRegistryNamespace(version string) string {
 	registryNamespace = os.Getenv("AWS_ECR_FOLIO_REPO")
 
 	return registryNamespace
+}
+
+func StripSnapshotFromImage(str string) string {
+	if idx := strings.LastIndex(str, "-"); idx != -1 {
+		result := str[:idx]
+		return result
+	}
+	return str
 }

--- a/eureka-cli/internal/module.go
+++ b/eureka-cli/internal/module.go
@@ -409,9 +409,6 @@ func DeployModules(commandName string, client *client.Client, dto *DeployModules
 
 			image := fmt.Sprintf("%s/%s:%s", DetermineImageRegistryNamespace(*module.Version), module.Name, *module.Version)
 
-			// TODO Strip out snapshot from the string
-			//image = StripSnapshotFromImage(image)
-
 			var combinedModuleEnvironment []string
 			combinedModuleEnvironment = append(combinedModuleEnvironment, dto.GlobalEnvironment...)
 			combinedModuleEnvironment = AppendModuleEnvironment(backendModule.ModuleEnvironment, combinedModuleEnvironment)
@@ -452,6 +449,7 @@ func DeployModules(commandName string, client *client.Client, dto *DeployModules
 	return deployedModules
 }
 
+// TODO fix this
 func DetermineImageRegistryNamespace(version string) string {
 	var registryNamespace string
 	//if strings.Contains(version, "SNAPSHOT") {
@@ -463,12 +461,4 @@ func DetermineImageRegistryNamespace(version string) string {
 	registryNamespace = os.Getenv("AWS_ECR_FOLIO_REPO")
 
 	return registryNamespace
-}
-
-func StripSnapshotFromImage(str string) string {
-	if idx := strings.LastIndex(str, "-"); idx != -1 {
-		result := str[:idx]
-		return result
-	}
-	return str
 }

--- a/eureka-cli/internal/registry.go
+++ b/eureka-cli/internal/registry.go
@@ -47,6 +47,7 @@ func NewRegisterModuleDto(registryUrls map[string]string,
 	}
 }
 
+// TODO wire this up the right way
 func GetEurekaRegistryAuthToken(commandName string) string {
 	session, err := session.NewSession()
 	if err != nil {

--- a/eureka-cli/internal/registry.go
+++ b/eureka-cli/internal/registry.go
@@ -4,7 +4,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"log"
 	"log/slog"
 	"net/http"
 	"os"
@@ -49,7 +48,7 @@ func NewRegisterModuleDto(registryUrls map[string]string,
 	}
 }
 
-func GetEurekaRegistryAuthToken(commandName string) string {
+func GetEurekaRegistryAuthTokenIfPresent(commandName string) string {
 	// If this env variable isn't set, then assume it is a public repository and no auth token is needed.
 	if os.Getenv(ecsRepoEnvKey) == "" {
 		return ""
@@ -93,7 +92,6 @@ func GetModulesFromRegistries(commandName string, installJsonUrls map[string]str
 	for registryName, installJsonUrl := range installJsonUrls {
 		var registryModules []*RegistryModule
 
-		log.Println("installJsonUrl ", installJsonUrl)
 		installJsonResp, err := http.Get(installJsonUrl)
 		if err != nil {
 			slog.Error(commandName, "http.Get error", "")
@@ -130,6 +128,7 @@ func GetModulesFromRegistries(commandName string, installJsonUrls map[string]str
 
 func GetImageRegistryNamespace(version string) string {
 	var registryNamespace string
+	// ECS registry should be considered a secret because it has an account id in it so we put it in the env.
 	registryNamespace = os.Getenv(ecsRepoEnvKey)
 
 	if registryNamespace != "" {

--- a/eureka-cli/internal/registry.go
+++ b/eureka-cli/internal/registry.go
@@ -48,7 +48,6 @@ func NewRegisterModuleDto(registryUrls map[string]string,
 	}
 }
 
-// TODO wire this up the right way
 func GetEurekaRegistryAuthToken(commandName string) string {
 	session, err := session.NewSession()
 	if err != nil {

--- a/eureka-cli/internal/registry.go
+++ b/eureka-cli/internal/registry.go
@@ -4,6 +4,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"log"
 	"log/slog"
 	"net/http"
 	"os"
@@ -87,6 +88,7 @@ func GetModulesFromRegistries(commandName string, installJsonUrls map[string]str
 	for registryName, installJsonUrl := range installJsonUrls {
 		var registryModules []*RegistryModule
 
+		log.Println("installJsonUrl ", installJsonUrl)
 		installJsonResp, err := http.Get(installJsonUrl)
 		if err != nil {
 			slog.Error(commandName, "http.Get error", "")

--- a/eureka-cli/misc/docker-compose.yaml
+++ b/eureka-cli/misc/docker-compose.yaml
@@ -175,11 +175,8 @@ services:
     deploy:
       resources:
         limits:
-          # TODO these aren't right. Should be integers I believe. Ignore for now.
-          #cpus: 1024m
           memory: 1200M
         reservations:
-          #cpus: 1024m
           memory: 1200M
 
   ### Kong ###

--- a/eureka-cli/misc/docker-compose.yaml
+++ b/eureka-cli/misc/docker-compose.yaml
@@ -175,10 +175,11 @@ services:
     deploy:
       resources:
         limits:
-          cpus: 1024m
+          # TODO these aren't right. Should be integers I believe. Ignore for now.
+          #cpus: 1024m
           memory: 1200M
         reservations:
-          cpus: 1024m
+          #cpus: 1024m
           memory: 1200M
 
   ### Kong ###


### PR DESCRIPTION
Allows for use of AWS ECR if the environment variable `AWS_ECR_FOLIO_REPO` is present. If this variable is present it is assumed that client credentials exist in the environment and that an token is needed. If no variable is present then the authtoken is "".

Also provides a new configuration property `port-server` which allows for a container's internal server port to be overridden by config.

Finally, provides a new `application.stripes-branch` configuration property to allow for the stripes container to be built from a specific branch such as `R1-2024` since `snapshot` was hard coded. This is needed because a user could choose to deploy a specific flower release rather than snapshot.

@BKadirkhodjaev I don't have a way to test easily on AMD but this code does work on ARM. Would be grateful if you could try it out on your system to make sure I haven't broken anything.