### PR TITLE
Fix readme

### DIFF
--- a/eureka-cli/AWS_CLI_PREPARATIONS.md
+++ b/eureka-cli/AWS_CLI_PREPARATIONS.md
@@ -1,0 +1,31 @@
+# AWS CLI Preparations
+
+## Purpose
+
+- AWS CLI preparation commands
+
+## Commands
+
+### Install AWS CLI
+
+> Download latest version for your OS from: <https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html>
+
+### Configure AWS CLI
+
+```shell
+aws configure set aws_access_key_id [access_key]
+aws configure set aws_secret_access_key [secret_key]
+aws configure set default.region [region]
+```
+
+### Login into AWS ECR
+
+```shell
+aws ecr get-login-password --region [region] | docker login --username [username] --password-stdin [account_id].dkr.ecr.[region].amazonaws.com
+```
+
+### (Optional) List available project versions
+
+```shell
+aws ecr list-images --repository-name [project_name] --no-paginate --output table
+```

--- a/eureka-cli/README.md
+++ b/eureka-cli/README.md
@@ -71,7 +71,7 @@ export AWS_ECR_FOLIO_REPO=<repository_url>
 AWS_SDK_LOAD_CONFIG=true ./bin/eureka-cli.exe -c ./config.minimal.yaml deployApplication
 ```
 
-> See AWS_CLI_PREPARATION.md to prepare AWS CLI beforehand
+> See AWS_CLI_PREPARATIONS.md to prepare AWS CLI beforehand
 
 - Undeploy using:
 

--- a/eureka-cli/README.md
+++ b/eureka-cli/README.md
@@ -50,11 +50,28 @@ env GOOS=windows GOARCH=amd64 go build -o ./bin .
 ```shell
 ./bin/eureka-cli.exe -c ./config.minimal.yaml deployApplication
 ```
-#### Useing AWS ECR
 
-To use AWS ECR as your container registry rather than the public folio DockerHub, set `AWS_ECR_FOLIO_REPO` in your environment. When this env variable is defined it is assumed that this repo is private and you have also defined credentials in your environment. The value of this variable should be the URL of your repository.
+#### Using Private AWS ECR image registry
 
-> See AWS_CLI_Preparation.md to prepare AWS CLI beforehand
+To use AWS ECR as your container registry rather than the public Folio DockerHub, set `AWS_ECR_FOLIO_REPO` in your environment. When this env variable is defined it is assumed that this repository is private and you have also defined credentials in your environment. The value of this variable should be the URL of your repository.
+
+- Set AWS credentials explicitly
+
+```shell
+export AWS_ACCESS_KEY_ID=<access_key>
+export AWS_SECRET_ACCESS_KEY=<secret_key>
+export AWS_ECR_FOLIO_REPO=<repository_url> 
+./bin/eureka-cli.exe -c ./config.minimal.yaml deployApplication
+```
+
+- Reuse stored AWS credentials found in `~/.aws/config`
+
+```shell
+export AWS_ECR_FOLIO_REPO=<repository_url>
+AWS_SDK_LOAD_CONFIG=true ./bin/eureka-cli.exe -c ./config.minimal.yaml deployApplication
+```
+
+> See AWS_CLI_PREPARATION.md to prepare AWS CLI beforehand
 
 - Undeploy using:
 

--- a/eureka-cli/README.md
+++ b/eureka-cli/README.md
@@ -50,15 +50,9 @@ env GOOS=windows GOARCH=amd64 go build -o ./bin .
 ```shell
 ./bin/eureka-cli.exe -c ./config.minimal.yaml deployApplication
 ```
+#### Useing AWS ECR
 
-#### Using Private AWS ECR image registry
-
-- Use a specific config: `-c` or `--config`
-- Enable debug: `-d` or `--debug`
-
-```shell
-AWS_SDK_LOAD_CONFIG=true ./bin/eureka-cli.exe -c ./config.minimal.yaml deployApplication
-```
+To use AWS ECR as your container registry rather than the public folio DockerHub, set `AWS_ECR_FOLIO_REPO` in your environment. When this env variable is defined it is assumed that this repo is private and you have also defined credentials in your environment. The value of this variable should be the URL of your repository.
 
 > See AWS_CLI_Preparation.md to prepare AWS CLI beforehand
 
@@ -83,10 +77,6 @@ curl --request POST \
   --data '{"username":"diku_admin","password": "admin"}' \
   --verbose
 ```
-
-### Use AWS ECR
-
-To use AWS ECR as your container registry rather than the public folio dockerhub, set `AWS_ECR_FOLIO_REPO` in your environment. When this env variable is defined it is assumed that this repo is private and you have also defined credentials in your environment.
 
 ### Troubleshooting
 


### PR DESCRIPTION
I think the variable `AWS_SDK_LOAD_CONFIG=true` doesn't exist in the code. Instead the code just looks for `AWS_ECR_FOLIO_REPO` and if it is defined uses the repo. See the `GetImageRegistryNamespace` function in registry.go for how this is used.