### PR TITLE
Allow override gateway hostname

### DIFF
--- a/eureka-cli/config.combined.yaml
+++ b/eureka-cli/config.combined.yaml
@@ -215,6 +215,8 @@ frontend-modules:
   folio_stripes-core:
   folio_notes:
   folio_stripes-smart-components:
+  folio_authorization-roles:
+  folio_authorization-policies:
   folio_users:
   folio_tenant-settings:
   folio_organizations:
@@ -231,3 +233,4 @@ frontend-modules:
   folio_plugin-find-po-line:
   folio_plugin-find-user:
   folio_plugin-select-application:
+  folio_plugin-find-authority:

--- a/eureka-cli/config.minimal.yaml
+++ b/eureka-cli/config.minimal.yaml
@@ -200,3 +200,7 @@ frontend-modules:
   folio_stripes-core:
   folio_notes:
   folio_stripes-smart-components:
+  folio_authorization-roles:
+  folio_authorization-policies:
+  folio_plugin-find-authority:
+  folio_plugin-select-application:

--- a/eureka-cli/internal/config.go
+++ b/eureka-cli/internal/config.go
@@ -18,13 +18,13 @@ const (
 	ConfigMinimal string = "config.minimal"
 	ConfigType    string = "yaml"
 
-	DockerComposeWorkDir  string = "./misc"
-	NetworkName           string = "fpm-net"
-	NetworkId             string = "eureka"
-	HostDockerInternalUrl string = "http://host.docker.internal:%d%s"
-	HostIp                string = "0.0.0.0"
-	DefaultServerPort     string = "8081"
-	DefaultDebugPort      string = "5005"
+	DockerComposeWorkDir string = "./misc"
+	DefaultNetworkName   string = "fpm-net"
+	DefaultNetworkId     string = "eureka"
+	DefaultHostname      string = "http://host.docker.internal:%d%s"
+	DefaultHostIp        string = "0.0.0.0"
+	DefaultServerPort    string = "8081"
+	DefaultDebugPort     string = "5005"
 
 	FolioKeycloakRepositoryUrl    string = "https://github.com/folio-org/folio-keycloak"
 	FolioKongRepositoryUrl        string = "https://github.com/folio-org/folio-kong"
@@ -39,6 +39,14 @@ const (
 )
 
 var PortStartIndex int = 30000
+
+func GetGatewayHostname() string {
+	if viper.IsSet(ApplicationGatewayHostnameKey) {
+		return viper.GetString(ApplicationGatewayHostnameKey) + ":%d%s"
+	}
+
+	return DefaultHostname
+}
 
 func GetBackendModulesFromConfig(commandName string, backendModulesAnyMap map[string]any, managementOnly bool) map[string]BackendModule {
 	const (
@@ -252,8 +260,8 @@ func PreparePackageJson(commandName string, configPath string, tenant string) {
 func GetStripesBranch(commandName string, defaultBranch plumbing.ReferenceName) plumbing.ReferenceName {
 	var stripesBranch plumbing.ReferenceName
 
-	if viper.IsSet(ApplicationStripesBranch) {
-		branchStr := viper.GetString(ApplicationStripesBranch)
+	if viper.IsSet(ApplicationStripesBranchKey) {
+		branchStr := viper.GetString(ApplicationStripesBranchKey)
 		stripesBranch = plumbing.ReferenceName(branchStr)
 		slog.Info(commandName, GetFuncName(), fmt.Sprintf("Got stripes branch from config: %s", stripesBranch))
 	} else {

--- a/eureka-cli/internal/module_model.go
+++ b/eureka-cli/internal/module_model.go
@@ -200,7 +200,7 @@ func NewDeploySidecarDto(name string,
 
 func NewModuleNetworkConfig() *network.NetworkingConfig {
 	return &network.NetworkingConfig{
-		EndpointsConfig: map[string]*network.EndpointSettings{NetworkName: {NetworkID: NetworkId}},
+		EndpointsConfig: map[string]*network.EndpointSettings{DefaultNetworkName: {NetworkID: DefaultNetworkId}},
 	}
 }
 
@@ -221,8 +221,8 @@ func createPortBindings(hostServerPort int, hostServerDebugPort int, serverPort 
 		serverDebugPortBinding []nat.PortBinding
 	)
 
-	serverPortBinding = append(serverPortBinding, nat.PortBinding{HostIP: HostIp, HostPort: strconv.Itoa(hostServerPort)})
-	serverDebugPortBinding = append(serverDebugPortBinding, nat.PortBinding{HostIP: HostIp, HostPort: strconv.Itoa(hostServerDebugPort)})
+	serverPortBinding = append(serverPortBinding, nat.PortBinding{HostIP: DefaultHostIp, HostPort: strconv.Itoa(hostServerPort)})
+	serverDebugPortBinding = append(serverDebugPortBinding, nat.PortBinding{HostIP: DefaultHostIp, HostPort: strconv.Itoa(hostServerDebugPort)})
 
 	portBindings := make(map[nat.Port][]nat.PortBinding)
 	portBindings[nat.Port(strconv.Itoa(serverPort))] = serverPortBinding

--- a/eureka-cli/internal/vault.go
+++ b/eureka-cli/internal/vault.go
@@ -17,7 +17,7 @@ const (
 )
 
 func GetVaultSecretKey(commandName string, enableDebug bool, vaultRootToken string, secretPath string) map[string]interface{} {
-	serverUrl := fmt.Sprintf(HostDockerInternalUrl, VaultServerPort, "")
+	serverUrl := fmt.Sprintf(GetGatewayHostname(), VaultServerPort, "")
 
 	client, err := vault.New(vault.WithAddress(serverUrl), vault.WithRequestTimeout(VaultTimeout))
 	if err != nil {

--- a/eureka-cli/internal/viper_keys.go
+++ b/eureka-cli/internal/viper_keys.go
@@ -3,9 +3,10 @@ package internal
 const (
 	ProfileNameKey string = "profile.name"
 
-	ApplicationKey           string = "application"
-	ApplicationPortStart     string = "application.port-start"
-	ApplicationStripesBranch string = "application.stripes-branch"
+	ApplicationKey                string = "application"
+	ApplicationPortStart          string = "application.port-start"
+	ApplicationStripesBranchKey   string = "application.stripes-branch"
+	ApplicationGatewayHostnameKey string = "application.gateway-hostname"
 
 	RegistryUrlKey                  string = "registry.registry-url"
 	RegistryFolioInstallJsonUrlKey  string = "registry.folio-install-json-url"


### PR DESCRIPTION
## Purpose

- Allow override gateway hostname for cases when `host.docker.internal` gateway hostname is not applicable

## Approach

- Add `GetGatewayHostname` method to resolve the hostname from a config