### PR TITLE
Add custom module deployment

### DIFF
--- a/eureka-cli/cmd/attachCapabilitySets.go
+++ b/eureka-cli/cmd/attachCapabilitySets.go
@@ -17,6 +17,7 @@ package cmd
 
 import (
 	"log/slog"
+	"sync"
 	"time"
 
 	"github.com/folio-org/eureka-cli/internal"
@@ -31,14 +32,14 @@ var attachCapabilitySetsCmd = &cobra.Command{
 	Short: "Attach capability sets",
 	Long:  `Attach capability sets to roles.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		AttachCapabilitySets(nil)
+		AttachCapabilitySets(nil, nil)
 	},
 }
 
-func AttachCapabilitySets(wait *time.Duration) {
-	if wait != nil && *wait > 0 {
+func AttachCapabilitySets(waitMutex *sync.WaitGroup, waitDuration *time.Duration) {
+	if waitMutex != nil && waitDuration != nil && *waitDuration > 0 {
 		slog.Info(attachCapabilitySetsCommand, internal.GetFuncName(), "### WAITING FOR CAPABILITY SETS TO SYNCHRONIZE ###")
-		time.Sleep(*wait)
+		time.Sleep(*waitDuration)
 	}
 
 	slog.Info(attachCapabilitySetsCommand, internal.GetFuncName(), "### ACQUIRING VAULT ROOT TOKEN ###")
@@ -59,6 +60,10 @@ func AttachCapabilitySets(wait *time.Duration) {
 
 		slog.Info(attachCapabilitySetsCommand, internal.GetFuncName(), "### ATTACHING CAPABILITY SETS TO ROLES ###")
 		internal.AttachCapabilitySetsToRoles(attachCapabilitySetsCommand, enableDebug, tenant, accessToken)
+	}
+
+	if waitMutex != nil {
+		waitMutex.Done()
 	}
 }
 

--- a/eureka-cli/cmd/attachCapabilitySets.go
+++ b/eureka-cli/cmd/attachCapabilitySets.go
@@ -17,6 +17,7 @@ package cmd
 
 import (
 	"log/slog"
+	"time"
 
 	"github.com/folio-org/eureka-cli/internal"
 	"github.com/spf13/cobra"
@@ -30,11 +31,16 @@ var attachCapabilitySetsCmd = &cobra.Command{
 	Short: "Attach capability sets",
 	Long:  `Attach capability sets to roles.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		AttachCapabilitySets()
+		AttachCapabilitySets(nil)
 	},
 }
 
-func AttachCapabilitySets() {
+func AttachCapabilitySets(wait *time.Duration) {
+	if wait != nil && *wait > 0 {
+		slog.Info(attachCapabilitySetsCommand, internal.GetFuncName(), "### WAITING FOR CAPABILITY SETS TO SYNCHRONIZE ###")
+		time.Sleep(*wait)
+	}
+
 	slog.Info(attachCapabilitySetsCommand, internal.GetFuncName(), "### ACQUIRING VAULT ROOT TOKEN ###")
 	client := internal.CreateClient(attachCapabilitySetsCommand)
 	defer client.Close()

--- a/eureka-cli/cmd/buildAndPushUi.go
+++ b/eureka-cli/cmd/buildAndPushUi.go
@@ -1,0 +1,93 @@
+/*
+Copyright © 2024 EPAM_Systems/Thunderjet/Boburbek_Kadirkhodjaev
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package cmd
+
+import (
+	"fmt"
+	"log/slog"
+	"os/exec"
+
+	"github.com/folio-org/eureka-cli/internal"
+	"github.com/spf13/cobra"
+)
+
+const buildAndPushUiCmdCommand string = "Build and push UI"
+
+var (
+	tenant    string
+	namespace string
+)
+
+// buildAndPushUiCmd represents the buildAndPushUi command
+var buildAndPushUiCmd = &cobra.Command{
+	Use:   "buildAndPushUi",
+	Short: "Build and push UI",
+	Long:  `Build and push UI image to DockerHub.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		BuildAndPushUi()
+	},
+}
+
+func BuildAndPushUi() {
+	slog.Info(deployUiCommand, internal.GetFuncName(), "### CLONING & UPDATING UI ###")
+
+	slog.Info(deployUiCommand, internal.GetFuncName(), fmt.Sprintf("Cloning %s from a %s branch", platformCompleteDir, defaultStripesBranch))
+	outputDir := fmt.Sprintf("%s/%s", internal.DockerComposeWorkDir, platformCompleteDir)
+	stripesBranch := internal.GetStripesBranch(deployUiCommand, defaultStripesBranch)
+	internal.GitCloneRepository(deployUiCommand, enableDebug, internal.PlatformCompleteRepositoryUrl, stripesBranch, outputDir, false)
+
+	if updateCloned {
+		slog.Info(deployUiCommand, internal.GetFuncName(), fmt.Sprintf("Pulling updates for %s from origin", platformCompleteDir))
+		internal.GitResetHardPullFromOriginRepository(deployUiCommand, enableDebug, internal.PlatformCompleteRepositoryUrl, defaultStripesBranch, outputDir)
+	}
+
+	slog.Info(deployUiCommand, internal.GetFuncName(), "### BUILDING AND PUSHING UI IMAGE TO DOCKER HUB ###")
+
+	slog.Info(buildAndPushUiCmdCommand, internal.GetFuncName(), "Copying platform complete UI configs")
+	configName := "stripes.config.js"
+	internal.CopySingleFile(buildAndPushUiCmdCommand, fmt.Sprintf("%s/eureka-tpl/%s", outputDir, configName), fmt.Sprintf("%s/%s", outputDir, configName))
+
+	slog.Info(buildAndPushUiCmdCommand, internal.GetFuncName(), "Preparing platform complete UI config")
+	internal.PrepareStripesConfigJs(buildAndPushUiCmdCommand, outputDir, tenant, kongExternalUrl, keycloakExternalUrl, platformCompleteExternalUrl)
+	internal.PreparePackageJson(buildAndPushUiCmdCommand, outputDir, tenant)
+
+	imageName := fmt.Sprintf("platform-complete-ui-%s", tenant)
+
+	slog.Info(buildAndPushUiCmdCommand, internal.GetFuncName(), "Building platform complete UI from a Dockerfile")
+	internal.RunCommandFromDir(buildAndPushUiCmdCommand, exec.Command("docker", "build", "--tag", imageName,
+		"--build-arg", fmt.Sprintf("OKAPI_URL=%s", kongExternalUrl),
+		"--build-arg", fmt.Sprintf("TENANT_ID=%s", tenant),
+		"--file", "./docker/Dockerfile",
+		"--progress", "plain",
+		"--no-cache",
+		".",
+	), outputDir)
+
+	slog.Info(buildAndPushUiCmdCommand, internal.GetFuncName(), "Tagging platform complete image UI")
+	internal.RunCommand(buildAndPushUiCmdCommand, exec.Command("docker", "tag", imageName, fmt.Sprintf("%s/%s", namespace, imageName)))
+
+	slog.Info(buildAndPushUiCmdCommand, internal.GetFuncName(), "Pushing platform complete UI image to DockerHub")
+	internal.RunCommand(buildAndPushUiCmdCommand, exec.Command("docker", "push", fmt.Sprintf("%s/%s:latest", namespace, imageName)))
+}
+
+func init() {
+	rootCmd.AddCommand(buildAndPushUiCmd)
+	buildAndPushUiCmd.PersistentFlags().StringVarP(&tenant, "tenant", "t", "", "Tenant (required)")
+	buildAndPushUiCmd.PersistentFlags().StringVarP(&namespace, "namespace", "n", "", "DockerHub namespace (required)")
+	buildAndPushUiCmd.PersistentFlags().BoolVarP(&updateCloned, "updateCloned", "u", false, "Update cloned projects")
+	buildAndPushUiCmd.MarkPersistentFlagRequired("tenant")
+	buildAndPushUiCmd.MarkPersistentFlagRequired("namespace")
+}

--- a/eureka-cli/cmd/deployApplication.go
+++ b/eureka-cli/cmd/deployApplication.go
@@ -16,8 +16,13 @@ limitations under the License.
 package cmd
 
 import (
+	"log/slog"
+	"time"
+
 	"github.com/spf13/cobra"
 )
+
+const deployApplicationCommand string = "Deploy Application"
 
 // deployApplicationCmd represents the deployApplication command
 var deployApplicationCmd = &cobra.Command{
@@ -30,6 +35,7 @@ var deployApplicationCmd = &cobra.Command{
 }
 
 func DeployApplication() {
+	start := time.Now()
 	DeploySystem()
 	DeployManagement()
 	DeployModules()
@@ -39,6 +45,7 @@ func DeployApplication() {
 	CreateUsers()
 	DeployUi()
 	AttachCapabilitySets()
+	slog.Info(deployApplicationCommand, "Elapsed, duration", time.Since(start))
 }
 
 func init() {

--- a/eureka-cli/cmd/deployApplication.go
+++ b/eureka-cli/cmd/deployApplication.go
@@ -43,8 +43,9 @@ func DeployApplication() {
 	CreateTenantEntitlements()
 	CreateRoles()
 	CreateUsers()
+	wait := 180 * time.Second
+	AttachCapabilitySets(&wait)
 	DeployUi()
-	AttachCapabilitySets()
 	slog.Info(deployApplicationCommand, "Elapsed, duration", time.Since(start))
 }
 

--- a/eureka-cli/cmd/deployModules.go
+++ b/eureka-cli/cmd/deployModules.go
@@ -46,10 +46,10 @@ func DeployModules() {
 	backendModulesMap := internal.GetBackendModulesFromConfig(deployModulesCommand, viper.GetStringMap(internal.BackendModuleKey), false)
 
 	slog.Info(deployModulesCommand, internal.GetFuncName(), "### READING FRONTEND MODULES FROM CONFIG ###")
-	frontendModulesMap := internal.GetFrontendModulesFromConfig(deployModulesCommand, viper.GetStringMap(internal.FrontendModuleKey))
+	frontendModulesMap := internal.GetFrontendModulesFromConfig(deployModulesCommand, viper.GetStringMap(internal.FrontendModuleKey), viper.GetStringMap(internal.CustomFrontendModuleKey))
 
 	slog.Info(deployModulesCommand, internal.GetFuncName(), "### READING BACKEND MODULE REGISTRIES ###")
-	instalJsonUrls := map[string]string{"folio": viper.GetString(internal.RegistryFolioInstallJsonUrlKey), "eureka": viper.GetString(internal.RegistryEurekaInstallJsonUrlKey)}
+	instalJsonUrls := map[string]string{internal.FolioRegistry: viper.GetString(internal.RegistryFolioInstallJsonUrlKey), internal.EurekaRegistry: viper.GetString(internal.RegistryEurekaInstallJsonUrlKey)}
 	registryModules := internal.GetModulesFromRegistries(deployModulesCommand, instalJsonUrls)
 
 	slog.Info(deployModulesCommand, internal.GetFuncName(), "### EXTRACTING MODULE NAME AND VERSION ###")
@@ -61,12 +61,12 @@ func DeployModules() {
 	vaultRootToken := internal.GetRootVaultToken(deployModulesCommand, client)
 
 	slog.Info(deployModulesCommand, internal.GetFuncName(), "### CREATING APPLICATIONS ###")
-	registryUrls := map[string]string{"folio": registryUrl, "eureka": registryUrl}
+	registryUrls := map[string]string{internal.FolioRegistry: registryUrl, "eureka": registryUrl}
 	registerModuleDto := internal.NewRegisterModuleDto(registryUrls, registryModules, backendModulesMap, frontendModulesMap, enableDebug)
 	internal.CreateApplications(deployModulesCommand, enableDebug, registerModuleDto)
 
 	slog.Info(deployModulesCommand, internal.GetFuncName(), "### DEPLOYING MODULES ###")
-	registryHostnames := map[string]string{"folio": "", "eureka": ""}
+	registryHostnames := map[string]string{internal.FolioRegistry: "", "eureka": ""}
 	deployModulesDto := internal.NewDeployModulesDto(vaultRootToken, registryHostnames, registryModules, backendModulesMap, environment, sidecarEnvironment)
 	deployedModules := internal.DeployModules(deployModulesCommand, client, deployModulesDto)
 

--- a/eureka-cli/cmd/getAccessToken.go
+++ b/eureka-cli/cmd/getAccessToken.go
@@ -25,9 +25,7 @@ import (
 
 const getAccessTokenCommand string = "Get Access Token"
 
-var (
-	tenant string
-)
+var realm string
 
 // getAccessTokenCmd represents the getAccessToken command
 var getAccessTokenCmd = &cobra.Command{
@@ -46,12 +44,12 @@ func GetAccessToken() {
 	vaultRootToken := internal.GetRootVaultToken(getAccessTokenCommand, client)
 
 	slog.Info(getAccessTokenCommand, internal.GetFuncName(), "### ACQUIRING KEYCLOAK ACCESS TOKEN ###")
-	accessToken := internal.GetKeycloakAccessToken(createUsersCommand, enableDebug, vaultRootToken, tenant)
+	accessToken := internal.GetKeycloakAccessToken(createUsersCommand, enableDebug, vaultRootToken, realm)
 	slog.Info(getAccessTokenCommand, internal.GetFuncName(), fmt.Sprintf("Access token: %s", accessToken))
 }
 
 func init() {
 	rootCmd.AddCommand(getAccessTokenCmd)
-	getAccessTokenCmd.PersistentFlags().StringVarP(&tenant, "realm", "r", "", "Realm (required)")
+	getAccessTokenCmd.PersistentFlags().StringVarP(&realm, "realm", "r", "", "Realm (required)")
 	getAccessTokenCmd.MarkPersistentFlagRequired("realm")
 }

--- a/eureka-cli/cmd/undeployApplication.go
+++ b/eureka-cli/cmd/undeployApplication.go
@@ -16,8 +16,13 @@ limitations under the License.
 package cmd
 
 import (
+	"log/slog"
+	"time"
+
 	"github.com/spf13/cobra"
 )
+
+const undeployApplicationCommand string = "Undeploy Application"
 
 // undeployApplicationCmd represents the undeployApplication command
 var undeployApplicationCmd = &cobra.Command{
@@ -30,10 +35,12 @@ var undeployApplicationCmd = &cobra.Command{
 }
 
 func UndeployApplication() {
+	start := time.Now()
 	UndeployUi()
 	UndeployModules()
 	UndeployManagement()
 	UndeploySystem()
+	slog.Info(undeployApplicationCommand, "Elapsed, duration", time.Since(start))
 }
 
 func init() {

--- a/eureka-cli/config.combined.yaml
+++ b/eureka-cli/config.combined.yaml
@@ -241,14 +241,6 @@ backend-modules:
       SYSTEM_USER_ENABLED: 'false'
       SYSTEM_USER_NAME: mod-search
       SYSTEM_USER_USERNAME: mod-search
-  mod-data-export-spring:
-    deploy-module: false
-    environment:
-      FOLIO_SYSTEM_USER_ENABLED: 'false'
-      SYSTEM_USER_CREATE: 'false'
-      SYSTEM_USER_ENABLED: 'false'
-      SYSTEM_USER_NAME: mod-data-export-spring
-      SYSTEM_USER_USERNAME: mod-data-export-spring
 # Frontend modules
 frontend-modules:
   folio_developer:

--- a/eureka-cli/config.combined.yaml
+++ b/eureka-cli/config.combined.yaml
@@ -193,8 +193,6 @@ backend-modules:
   mod-roles:
   mod-password-validator:
   mod-settings:
-  mod-notes:
-  mod-tags:
   mod-inventory-storage:
   mod-inventory:
     port-server: 9403
@@ -213,13 +211,9 @@ backend-modules:
   mod-circulation-storage:
   mod-circulation:
     port-server: 9801
-  mod-login-saml:
-  mod-event-config:
-  mod-template-engine:
 # Frontend modules
 frontend-modules:
   folio_developer:
-  folio_tags:
   folio_stripes-core:
   folio_notes:
   folio_stripes-smart-components:

--- a/eureka-cli/config.combined.yaml
+++ b/eureka-cli/config.combined.yaml
@@ -221,8 +221,6 @@ frontend-modules:
   folio_stripes-core:
   folio_notes:
   folio_stripes-smart-components:
-  folio_authorization-roles:
-  folio_authorization-policies:
   folio_users:
   folio_tenant-settings:
   folio_organizations:
@@ -238,5 +236,12 @@ frontend-modules:
   folio_plugin-find-organization:
   folio_plugin-find-po-line:
   folio_plugin-find-user:
-  folio_plugin-select-application:
   folio_plugin-find-authority:
+# Custom Frontend modules
+custom-frontend-modules:
+  folio_authorization-roles:
+    version: 1.6.10990000000025
+  folio_authorization-policies:
+    version: 1.3.10990000000015
+  folio_plugin-select-application:
+    version: 1.1.1099000000003

--- a/eureka-cli/config.combined.yaml
+++ b/eureka-cli/config.combined.yaml
@@ -13,6 +13,8 @@ registry:
   registry-url: https://folio-registry.dev.folio.org
   folio-install-json-url: https://raw.githubusercontent.com/folio-org/platform-complete/snapshot/install.json
   eureka-install-json-url: https://raw.githubusercontent.com/folio-org/platform-complete/snapshot/eureka-platform.json
+  namespaces:
+    platform-complete-ui: bkadirkhodjaev
 # Environment
 environment:
   # General

--- a/eureka-cli/config.combined.yaml
+++ b/eureka-cli/config.combined.yaml
@@ -166,9 +166,12 @@ backend-modules:
     environment:
       OKAPI_URL: http://mod-users-keycloak-sc.eureka:8081
       INCLUDE_ONLY_VISIBLE_PERMISSIONS: 'false'
+      MOD_USERS_URL: http://mod-users.eureka
+      FOLIO_SYSTEM_USER_ENABLED: 'false'
+      SYSTEM_USER_CREATE: 'false'
+      SYSTEM_USER_ENABLED: 'false'
       SYSTEM_USER_NAME: mod-users-keycloak
       SYSTEM_USER_USERNAME: mod-users-keycloak
-      MOD_USERS_URL: http://mod-users.eureka
   mod-login-keycloak:
     port: 9905
     sidecar: true
@@ -180,11 +183,23 @@ backend-modules:
   mod-scheduler:
     port: 9907
     sidecar: true
+    environment:
+      FOLIO_SYSTEM_USER_ENABLED: 'false'
+      SYSTEM_USER_CREATE: 'false'
+      SYSTEM_USER_ENABLED: 'false'
+      SYSTEM_USER_NAME: mod-scheduler
+      SYSTEM_USER_USERNAME: mod-scheduler
   # Keycloak Consortia modules
   mod-consortia-keycloak:
     deploy-module: false
     port: 9908
     sidecar: true
+    environment:
+      FOLIO_SYSTEM_USER_ENABLED: 'false'
+      SYSTEM_USER_CREATE: 'false'
+      SYSTEM_USER_ENABLED: 'false'
+      SYSTEM_USER_NAME: mod-consortia-keycloak
+      SYSTEM_USER_USERNAME: mod-consortia-keycloak
   # Core Modules
   mod-permissions:
   mod-configuration:
@@ -209,10 +224,31 @@ backend-modules:
   mod-audit:
   mod-pubsub:
     environment:
+      FOLIO_SYSTEM_USER_ENABLED: 'false'
+      SYSTEM_USER_CREATE: 'false'
+      SYSTEM_USER_ENABLED: 'false'
       SYSTEM_USER_NAME: mod-pubsub
+      SYSTEM_USER_USERNAME: mod-pubsub
   mod-circulation-storage:
   mod-circulation:
     port-server: 9801
+  # Requires Elasticsearch to be uncommented in misc/docker-compose.yaml
+  mod-search:
+    deploy-module: false
+    environment:
+      FOLIO_SYSTEM_USER_ENABLED: 'false'
+      SYSTEM_USER_CREATE: 'false'
+      SYSTEM_USER_ENABLED: 'false'
+      SYSTEM_USER_NAME: mod-search
+      SYSTEM_USER_USERNAME: mod-search
+  mod-data-export-spring:
+    deploy-module: false
+    environment:
+      FOLIO_SYSTEM_USER_ENABLED: 'false'
+      SYSTEM_USER_CREATE: 'false'
+      SYSTEM_USER_ENABLED: 'false'
+      SYSTEM_USER_NAME: mod-data-export-spring
+      SYSTEM_USER_USERNAME: mod-data-export-spring
 # Frontend modules
 frontend-modules:
   folio_developer:

--- a/eureka-cli/config.combined.yaml
+++ b/eureka-cli/config.combined.yaml
@@ -193,6 +193,8 @@ backend-modules:
   mod-roles:
   mod-password-validator:
   mod-settings:
+  mod-notes:
+  mod-tags:
   mod-inventory-storage:
   mod-inventory:
     port-server: 9403
@@ -216,6 +218,7 @@ frontend-modules:
   folio_developer:
   folio_stripes-core:
   folio_notes:
+  folio_tags:
   folio_stripes-smart-components:
   folio_users:
   folio_tenant-settings:

--- a/eureka-cli/config.minimal.yaml
+++ b/eureka-cli/config.minimal.yaml
@@ -13,6 +13,8 @@ registry:
   registry-url: https://folio-registry.dev.folio.org
   folio-install-json-url: https://raw.githubusercontent.com/folio-org/platform-complete/snapshot/install.json
   eureka-install-json-url: https://raw.githubusercontent.com/folio-org/platform-complete/snapshot/eureka-platform.json
+  namespaces:
+    platform-complete-ui: bkadirkhodjaev
 # Environment
 environment:
   # General

--- a/eureka-cli/config.minimal.yaml
+++ b/eureka-cli/config.minimal.yaml
@@ -200,7 +200,12 @@ frontend-modules:
   folio_stripes-core:
   folio_notes:
   folio_stripes-smart-components:
-  folio_authorization-roles:
-  folio_authorization-policies:
   folio_plugin-find-authority:
+# Custom Frontend modules
+custom-frontend-modules:
+  folio_authorization-roles:
+    version: 1.6.10990000000025
+  folio_authorization-policies:
+    version: 1.3.10990000000015
   folio_plugin-select-application:
+    version: 1.1.1099000000003

--- a/eureka-cli/config.minimal.yaml
+++ b/eureka-cli/config.minimal.yaml
@@ -166,9 +166,12 @@ backend-modules:
     environment:
       OKAPI_URL: http://mod-users-keycloak-sc.eureka:8081
       INCLUDE_ONLY_VISIBLE_PERMISSIONS: 'false'
+      MOD_USERS_URL: http://mod-users.eureka
+      FOLIO_SYSTEM_USER_ENABLED: 'false'
+      SYSTEM_USER_CREATE: 'false'
+      SYSTEM_USER_ENABLED: 'false'
       SYSTEM_USER_NAME: mod-users-keycloak
       SYSTEM_USER_USERNAME: mod-users-keycloak
-      MOD_USERS_URL: http://mod-users.eureka
   mod-login-keycloak:
     port: 9905
     sidecar: true
@@ -180,11 +183,23 @@ backend-modules:
   mod-scheduler:
     port: 9907
     sidecar: true
+    environment:
+      FOLIO_SYSTEM_USER_ENABLED: 'false'
+      SYSTEM_USER_CREATE: 'false'
+      SYSTEM_USER_ENABLED: 'false'
+      SYSTEM_USER_NAME: mod-scheduler
+      SYSTEM_USER_USERNAME: mod-scheduler
   # Keycloak Consortia modules
   mod-consortia-keycloak:
     deploy-module: false
     port: 9908
     sidecar: true
+    environment:
+      FOLIO_SYSTEM_USER_ENABLED: 'false'
+      SYSTEM_USER_CREATE: 'false'
+      SYSTEM_USER_ENABLED: 'false'
+      SYSTEM_USER_NAME: mod-consortia-keycloak
+      SYSTEM_USER_USERNAME: mod-consortia-keycloak
   # Core Modules
   mod-permissions:
   mod-configuration:
@@ -198,9 +213,9 @@ backend-modules:
 # Frontend modules
 frontend-modules:
   folio_developer:
-  folio_tags:
   folio_stripes-core:
   folio_notes:
+  folio_tags:
   folio_stripes-smart-components:
   folio_plugin-find-authority:
 # Custom Frontend modules

--- a/eureka-cli/internal/config.go
+++ b/eureka-cli/internal/config.go
@@ -229,7 +229,10 @@ func PrepareStripesConfigJs(commandName string, configPath string, tenant string
 		newReadFileStr = strings.Replace(newReadFileStr, key, value, -1)
 	}
 
+	fmt.Println()
+	fmt.Println("###### Dumping stripes.config.js ######")
 	fmt.Println(newReadFileStr)
+	fmt.Println()
 
 	err = os.WriteFile(stripesConfigJsFilePath, []byte(newReadFileStr), 0)
 	if err != nil {
@@ -252,6 +255,8 @@ func PreparePackageJson(commandName string, configPath string, tenant string) {
 	}
 
 	ReadJsonFromFile(commandName, packageJsonPath, &packageJson)
+
+	packageJson.Scripts["build"] = "export DEBUG=stripes*; export NODE_OPTIONS=\"--max-old-space-size=8000 $NODE_OPTIONS\"; stripes build stripes.config.js --languages en --sourcemap=false --no-minify"
 
 	updates := 0
 	modules := []string{"@folio/authorization-policies", "@folio/authorization-roles", "@folio/plugin-select-application"}

--- a/eureka-cli/internal/config.go
+++ b/eureka-cli/internal/config.go
@@ -18,6 +18,9 @@ const (
 	ConfigMinimal string = "config.minimal"
 	ConfigType    string = "yaml"
 
+	FolioRegistry  string = "folio"
+	EurekaRegistry string = "eureka"
+
 	DockerComposeWorkDir string = "./misc"
 	DefaultNetworkName   string = "fpm-net"
 	DefaultNetworkId     string = "eureka"
@@ -157,7 +160,7 @@ func GetBackendModulesFromConfig(commandName string, backendModulesAnyMap map[st
 	return backendModulesMap
 }
 
-func GetFrontendModulesFromConfig(commandName string, frontendModulesAnyMap map[string]any) map[string]FrontendModule {
+func GetFrontendModulesFromConfig(commandName string, frontendModulesAnyMaps ...map[string]any) map[string]FrontendModule {
 	const (
 		DeployModuleKey = "deploy-module"
 		VersionKey      = "version"
@@ -165,33 +168,35 @@ func GetFrontendModulesFromConfig(commandName string, frontendModulesAnyMap map[
 
 	frontendModulesMap := make(map[string]FrontendModule)
 
-	for name, value := range frontendModulesAnyMap {
-		var (
-			deployModule bool = true
-			version      *string
-		)
+	for _, frontendModulesAnyMap := range frontendModulesAnyMaps {
+		for name, value := range frontendModulesAnyMap {
+			var (
+				deployModule bool = true
+				version      *string
+			)
 
-		if value != nil {
-			mapEntry := value.(map[string]interface{})
+			if value != nil {
+				mapEntry := value.(map[string]interface{})
 
-			if mapEntry[DeployModuleKey] != nil {
-				deployModule = mapEntry[DeployModuleKey].(bool)
+				if mapEntry[DeployModuleKey] != nil {
+					deployModule = mapEntry[DeployModuleKey].(bool)
+				}
+
+				if mapEntry[VersionKey] != nil {
+					versionValue := mapEntry[VersionKey].(string)
+					version = &versionValue
+				}
 			}
 
-			if mapEntry[VersionKey] != nil {
-				versionValue := mapEntry[VersionKey].(string)
-				version = &versionValue
+			frontendModulesMap[name] = *NewFrontendModule(deployModule, name, version)
+
+			moduleInfo := name
+			if version != nil {
+				moduleInfo = fmt.Sprintf("name %s with version %s", name, *version)
 			}
+
+			slog.Info(commandName, GetFuncName(), fmt.Sprintf("Found frontend module in config: %s", moduleInfo))
 		}
-
-		frontendModulesMap[name] = *NewFrontendModule(deployModule, name, version)
-
-		moduleInfo := name
-		if version != nil {
-			moduleInfo = fmt.Sprintf("name %s with version %s", name, *version)
-		}
-
-		slog.Info(commandName, GetFuncName(), fmt.Sprintf("Found frontend module in config: %s", moduleInfo))
 	}
 
 	return frontendModulesMap

--- a/eureka-cli/internal/keycloak.go
+++ b/eureka-cli/internal/keycloak.go
@@ -34,6 +34,7 @@ func GetKeycloakAccessToken(commandName string, enableDebug bool, vaultRootToken
 	tokensMap := DoPostFormDataReturnMapStringInteface(commandName, requestUrl, enableDebug, formData, headers)
 	if tokensMap["access_token"] == nil {
 		LogErrorPanic(commandName, "internal.GetKeycloakAccessToken - Access token not found")
+		return ""
 	}
 
 	return tokensMap["access_token"].(string)
@@ -52,6 +53,7 @@ func GetKeycloakMasterRealmAccessToken(commandName string, enableDebug bool) str
 	tokensMap := DoPostFormDataReturnMapStringInteface(commandName, requestUrl, enableDebug, formData, headers)
 	if tokensMap["access_token"] == nil {
 		LogErrorPanic(commandName, "internal.GetKeycloakAccessToken - Access token not found")
+		return ""
 	}
 
 	return tokensMap["access_token"].(string)
@@ -65,6 +67,7 @@ func UpdateKeycloakPublicClientParams(commandName string, enableDebug bool, tena
 	foundClients := DoGetDecodeReturnInterface(commandName, getRequestUrl, enableDebug, true, headers).([]interface{})
 	if len(foundClients) != 1 {
 		LogErrorPanic(commandName, fmt.Sprintf("internal.UpdateKeycloakPublicClientParams - Number of found cliends by %s client id is not 1", clientId))
+		return
 	}
 
 	clientUuid := foundClients[0].(map[string]interface{})["id"].(string)

--- a/eureka-cli/internal/management.go
+++ b/eureka-cli/internal/management.go
@@ -164,7 +164,6 @@ func CreateApplications(commandName string, enableDebug bool, dto *RegisterModul
 			}
 
 			backendModule, okBackend := dto.BackendModulesMap[module.Name]
-
 			frontendModule, okFrontend := dto.FrontendModulesMap[module.Name]
 			if (!okBackend && !okFrontend) || (okBackend && !backendModule.DeployModule || okFrontend && !frontendModule.DeployModule) {
 				continue
@@ -179,7 +178,7 @@ func CreateApplications(commandName string, enableDebug bool, dto *RegisterModul
 				module.Id = fmt.Sprintf("%s-%s", module.Name, *module.Version)
 			}
 
-			moduleDescriptorUrl := fmt.Sprintf("%s/_/proxy/modules/%s", dto.RegistryUrls["folio"], module.Id)
+			moduleDescriptorUrl := fmt.Sprintf("%s/_/proxy/modules/%s", dto.RegistryUrls[FolioRegistry], module.Id)
 
 			if applicationFetchDescriptors {
 				dto.ModuleDescriptorsMap[module.Id] = DoGetDecodeReturnInterface(commandName, moduleDescriptorUrl, enableDebug, true, map[string]string{})

--- a/eureka-cli/internal/management.go
+++ b/eureka-cli/internal/management.go
@@ -524,6 +524,7 @@ func GetRoleByName(commandName string, enableDebug bool, roleName string, header
 	foundRoles := foundRolesMap["roles"].([]interface{})
 	if len(foundRoles) != 1 {
 		LogErrorPanic(commandName, fmt.Sprintf("internal.GetRoleByName - Number of found roles by %s role name is not 1", roleName))
+		return nil
 	}
 
 	return foundRoles[0].(map[string]interface{})

--- a/eureka-cli/internal/registry.go
+++ b/eureka-cli/internal/registry.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ecr"
+	"github.com/spf13/viper"
 )
 
 const (
@@ -76,6 +77,21 @@ func GetModulesFromRegistries(commandName string, installJsonUrls map[string]str
 		if err != nil {
 			slog.Error(commandName, GetFuncName(), "json.NewDecoder error")
 			panic(err)
+		}
+
+		if registryName == FolioRegistry {
+			for name, value := range viper.GetStringMap(CustomFrontendModuleKey) {
+				if value == nil {
+					continue
+				}
+
+				mapEntry := value.(map[string]interface{})
+				if mapEntry["version"] == nil {
+					continue
+				}
+
+				registryModules = append(registryModules, &RegistryModule{Id: fmt.Sprintf("%s-%s", name, mapEntry["version"].(string)), Action: "enable"})
+			}
 		}
 
 		if len(registryModules) > 0 {

--- a/eureka-cli/internal/viper_keys.go
+++ b/eureka-cli/internal/viper_keys.go
@@ -22,4 +22,5 @@ const (
 	SidecarModuleEnvironmentKey string = "sidecar-module.environment"
 	BackendModuleKey            string = "backend-modules"
 	FrontendModuleKey           string = "frontend-modules"
+	CustomFrontendModuleKey     string = "custom-frontend-modules"
 )

--- a/eureka-cli/internal/viper_keys.go
+++ b/eureka-cli/internal/viper_keys.go
@@ -8,9 +8,10 @@ const (
 	ApplicationStripesBranchKey   string = "application.stripes-branch"
 	ApplicationGatewayHostnameKey string = "application.gateway-hostname"
 
-	RegistryUrlKey                  string = "registry.registry-url"
-	RegistryFolioInstallJsonUrlKey  string = "registry.folio-install-json-url"
-	RegistryEurekaInstallJsonUrlKey string = "registry.eureka-install-json-url"
+	RegistryUrlKey                          string = "registry.registry-url"
+	RegistryFolioInstallJsonUrlKey          string = "registry.folio-install-json-url"
+	RegistryEurekaInstallJsonUrlKey         string = "registry.eureka-install-json-url"
+	RegistryNamespacesPlatformCompleteUiKey string = "registry.namespaces.platform-complete-ui"
 
 	EnvironmentKey string = "environment"
 

--- a/eureka-cli/misc/docker-compose.yaml
+++ b/eureka-cli/misc/docker-compose.yaml
@@ -229,6 +229,33 @@ services:
       interval: 10s
       timeout: 10s
       retries: 10
+  
+  ### Elasticsearch ###
+  # An optional service when deploying mod-search
+  # kibana:
+  #   container_name: kibana
+  #   image: bitnami/kibana:8.16.1
+  #   restart: unless-stopped
+  #   environment:
+  #     ELASTICSEARCH_HOSTS: '["http://elasticsearch:9200"]'
+  #   networks: 
+  #     - fpm-net
+  #   ports:
+  #     - 15601:5601 
+ 
+  # A required service when deploying mod-search
+  # elasticsearch:
+  #   container_name: elasticsearch
+  #   image: bitnami/elasticsearch:8.16.1
+  #   restart: unless-stopped
+  #   environment:
+  #     ELASTICSEARCH_PLUGINS:
+  #       "analysis-icu,analysis-kuromoji,analysis-smartcn,analysis-nori,analysis-phonetic"
+  #   networks: 
+  #     - fpm-net
+  #   ports:
+  #     - 9200:9200
+  #     - 9300:9300
       
   ### Netcat ###
   netcat:
@@ -251,4 +278,4 @@ services:
       retries: 15
       start_period: 5s
 
-  # TODO Add Elasticsearch, Kibana and Minio
+  # TODO Minio

--- a/eureka-cli/misc/docker-compose.yaml
+++ b/eureka-cli/misc/docker-compose.yaml
@@ -242,6 +242,11 @@ services:
   #     - fpm-net
   #   ports:
   #     - 15601:5601 
+  #   healthcheck:
+  #     test: [ "CMD-SHELL", "curl -s -I http://localhost:5601 | grep -q 'HTTP/1.1 302 Found'" ]
+  #     interval: 10s
+  #     timeout: 10s
+  #     retries: 120
  
   # A required service when deploying mod-search
   # elasticsearch:
@@ -256,6 +261,11 @@ services:
   #   ports:
   #     - 9200:9200
   #     - 9300:9300
+  #   healthcheck:
+  #     test: curl -s http://elasticsearch:9200 >/dev/null || exit 1
+  #     interval: 30s
+  #     timeout: 10s
+  #     retries: 30
       
   ### Netcat ###
   netcat:
@@ -277,5 +287,5 @@ services:
       timeout: 5s
       retries: 15
       start_period: 5s
-
+      
   # TODO Minio


### PR DESCRIPTION
## Purpose

- Add custom module deployment to install Eureka frontend modules not currently managed by Folio public registry

> Frontend modules not found in <https://raw.githubusercontent.com/folio-org/platform-complete/snapshot/install.json>
>  - `folio_authorization-roles`
> - `folio_authorization-policies`
>  - `folio_plugin-select-application`

- Add `buildAndPushUi` to build and push UI image to a remote public registry 
- Change `deployUi` command to support pulling a ready-made image from a public registry

> Public registry in question: https://hub.docker.com/r/bkadirkhodjaev/platform-complete-ui-diku

- Remove redundant modules from Combined config: `mod-login-saml`,  `mod-event-config`, `mod-template-engine`
- Add support to deploy `mod-search` and `mod-data-export-spring`

> By default `mod-search` deployment is disabled, to enable uncomment service in docker-compose and set `deploy-module: true` in the `config.combined.yaml`

## Approach

- Add `custom-frontend-module` parsing and injection into registry modules and frontend modules from the config