### PR TITLE
Improve exception handling and tenant check, bump UI modules

### DIFF
--- a/eureka-cli/cmd/attachCapabilitySets.go
+++ b/eureka-cli/cmd/attachCapabilitySets.go
@@ -16,6 +16,7 @@ limitations under the License.
 package cmd
 
 import (
+	"fmt"
 	"log/slog"
 	"sync"
 	"time"
@@ -49,17 +50,17 @@ func AttachCapabilitySets(waitMutex *sync.WaitGroup, waitDuration *time.Duration
 
 	for _, tenantValue := range internal.GetTenants(attachCapabilitySetsCommand, enableDebug, false) {
 		tenantMapEntry := tenantValue.(map[string]interface{})
-		tenant := tenantMapEntry["name"].(string)
 
-		if !internal.HasTenant(tenant) {
+		existingTenant := tenantMapEntry["name"].(string)
+		if !internal.HasTenant(existingTenant) {
 			continue
 		}
 
-		slog.Info(attachCapabilitySetsCommand, internal.GetFuncName(), "### ACQUIRING KEYCLOAK ACCESS TOKEN ###")
-		accessToken := internal.GetKeycloakAccessToken(attachCapabilitySetsCommand, enableDebug, vaultRootToken, tenant)
+		slog.Info(attachCapabilitySetsCommand, internal.GetFuncName(), fmt.Sprintf("### ACQUIRING KEYCLOAK ACCESS TOKEN FOR %s TENANT ###", existingTenant))
+		accessToken := internal.GetKeycloakAccessToken(attachCapabilitySetsCommand, enableDebug, vaultRootToken, existingTenant)
 
-		slog.Info(attachCapabilitySetsCommand, internal.GetFuncName(), "### ATTACHING CAPABILITY SETS TO ROLES ###")
-		internal.AttachCapabilitySetsToRoles(attachCapabilitySetsCommand, enableDebug, tenant, accessToken)
+		slog.Info(attachCapabilitySetsCommand, internal.GetFuncName(), fmt.Sprintf("### ATTACHING CAPABILITY SETS TO ROLES FOR %s TENANT ###", existingTenant))
+		internal.AttachCapabilitySetsToRoles(attachCapabilitySetsCommand, enableDebug, existingTenant, accessToken)
 	}
 
 	if waitMutex != nil {

--- a/eureka-cli/cmd/buildAndPushUi.go
+++ b/eureka-cli/cmd/buildAndPushUi.go
@@ -56,7 +56,7 @@ func BuildAndPushUi() {
 	internal.CopySingleFile(buildAndPushUiCmdCommand, fmt.Sprintf("%s/eureka-tpl/%s", outputDir, configName), fmt.Sprintf("%s/%s", outputDir, configName))
 
 	slog.Info(buildAndPushUiCmdCommand, internal.GetFuncName(), "Preparing platform complete UI config")
-	internal.PrepareStripesConfigJs(buildAndPushUiCmdCommand, outputDir, tenant, kongExternalUrl, keycloakExternalUrl, platformCompleteExternalUrl)
+	internal.PrepareStripesConfigJs(buildAndPushUiCmdCommand, outputDir, tenant, kongExternalUrl, keycloakExternalUrl, platformCompleteExternalUrl, enableEcsRequests)
 	internal.PreparePackageJson(buildAndPushUiCmdCommand, outputDir, tenant)
 
 	imageName := fmt.Sprintf("platform-complete-ui-%s", tenant)
@@ -83,6 +83,7 @@ func init() {
 	buildAndPushUiCmd.PersistentFlags().StringVarP(&tenant, "tenant", "t", "", "Tenant (required)")
 	buildAndPushUiCmd.PersistentFlags().StringVarP(&namespace, "namespace", "n", "", "DockerHub namespace (required)")
 	buildAndPushUiCmd.PersistentFlags().BoolVarP(&updateCloned, "updateCloned", "u", false, "Update cloned projects")
+	buildAndPushUiCmd.PersistentFlags().BoolVarP(&enableEcsRequests, "enableEcsRequests", "e", false, "Enable ECS requests")
 	buildAndPushUiCmd.MarkPersistentFlagRequired("tenant")
 	buildAndPushUiCmd.MarkPersistentFlagRequired("namespace")
 }

--- a/eureka-cli/cmd/createRoles.go
+++ b/eureka-cli/cmd/createRoles.go
@@ -16,6 +16,7 @@ limitations under the License.
 package cmd
 
 import (
+	"fmt"
 	"log/slog"
 
 	"github.com/folio-org/eureka-cli/internal"
@@ -42,17 +43,17 @@ func CreateRoles() {
 
 	for _, value := range internal.GetTenants(createRolesCommand, enableDebug, false) {
 		mapEntry := value.(map[string]interface{})
-		tenant := mapEntry["name"].(string)
 
-		if !internal.HasTenant(tenant) {
+		existingTenant := mapEntry["name"].(string)
+		if !internal.HasTenant(existingTenant) {
 			continue
 		}
 
-		slog.Info(createRolesCommand, internal.GetFuncName(), "### ACQUIRING KEYCLOAK ACCESS TOKEN ###")
-		accessToken := internal.GetKeycloakAccessToken(createRolesCommand, enableDebug, vaultRootToken, tenant)
+		slog.Info(createRolesCommand, internal.GetFuncName(), fmt.Sprintf("### ACQUIRING KEYCLOAK ACCESS TOKEN FOR %s TENANT ###", existingTenant))
+		accessToken := internal.GetKeycloakAccessToken(createRolesCommand, enableDebug, vaultRootToken, existingTenant)
 
-		slog.Info(createRolesCommand, internal.GetFuncName(), "### CREATING ROLES ###")
-		internal.CreateRoles(createRolesCommand, enableDebug, accessToken)
+		slog.Info(createRolesCommand, internal.GetFuncName(), fmt.Sprintf("### CREATING ROLES FOR %s TENANT ###", existingTenant))
+		internal.CreateRoles(createRolesCommand, enableDebug, false, existingTenant, accessToken)
 	}
 }
 

--- a/eureka-cli/cmd/createUsers.go
+++ b/eureka-cli/cmd/createUsers.go
@@ -16,6 +16,7 @@ limitations under the License.
 package cmd
 
 import (
+	"fmt"
 	"log/slog"
 
 	"github.com/folio-org/eureka-cli/internal"
@@ -42,17 +43,17 @@ func CreateUsers() {
 
 	for _, value := range internal.GetTenants(createUsersCommand, enableDebug, false) {
 		mapEntry := value.(map[string]interface{})
-		tenant := mapEntry["name"].(string)
 
-		if !internal.HasTenant(tenant) {
+		existingTenant := mapEntry["name"].(string)
+		if !internal.HasTenant(existingTenant) {
 			continue
 		}
 
-		slog.Info(createUsersCommand, internal.GetFuncName(), "### ACQUIRING KEYCLOAK ACCESS TOKEN ###")
-		accessToken := internal.GetKeycloakAccessToken(createUsersCommand, enableDebug, vaultRootToken, tenant)
+		slog.Info(createUsersCommand, internal.GetFuncName(), fmt.Sprintf("### ACQUIRING KEYCLOAK ACCESS TOKEN FOR %s TENANT ###", existingTenant))
+		accessToken := internal.GetKeycloakAccessToken(createUsersCommand, enableDebug, vaultRootToken, existingTenant)
 
-		slog.Info(createUsersCommand, internal.GetFuncName(), "### CREATING USERS ###")
-		internal.CreateUsers(createUsersCommand, enableDebug, accessToken)
+		slog.Info(createUsersCommand, internal.GetFuncName(), fmt.Sprintf("### CREATING USERS FOR %s TENANT ###", existingTenant))
+		internal.CreateUsers(createUsersCommand, enableDebug, false, existingTenant, accessToken)
 	}
 }
 

--- a/eureka-cli/cmd/detachCapabilitySets.go
+++ b/eureka-cli/cmd/detachCapabilitySets.go
@@ -16,6 +16,7 @@ limitations under the License.
 package cmd
 
 import (
+	"fmt"
 	"log/slog"
 
 	"github.com/folio-org/eureka-cli/internal"
@@ -42,17 +43,17 @@ func DetachCapabilitySets() {
 
 	for _, value := range internal.GetTenants(detachCapabilitySetsCommand, enableDebug, false) {
 		mapEntry := value.(map[string]interface{})
-		tenant := mapEntry["name"].(string)
 
-		if !internal.HasTenant(tenant) {
+		existingTenant := mapEntry["name"].(string)
+		if !internal.HasTenant(existingTenant) {
 			continue
 		}
 
-		slog.Info(detachCapabilitySetsCommand, internal.GetFuncName(), "### ACQUIRING KEYCLOAK ACCESS TOKEN ###")
-		accessToken := internal.GetKeycloakAccessToken(detachCapabilitySetsCommand, enableDebug, vaultRootToken, tenant)
+		slog.Info(detachCapabilitySetsCommand, internal.GetFuncName(), fmt.Sprintf("### ACQUIRING KEYCLOAK ACCESS TOKEN FOR %s TENANT ###", existingTenant))
+		accessToken := internal.GetKeycloakAccessToken(detachCapabilitySetsCommand, enableDebug, vaultRootToken, existingTenant)
 
-		slog.Info(detachCapabilitySetsCommand, internal.GetFuncName(), "### DETACHING CAPABILITY SETS FROM ROLES ###")
-		internal.DetachCapabilitySetsFromRoles(detachCapabilitySetsCommand, enableDebug, false, tenant, accessToken)
+		slog.Info(detachCapabilitySetsCommand, internal.GetFuncName(), fmt.Sprintf("### DETACHING CAPABILITY SETS FROM ROLES FOR %s TENANT ###", existingTenant))
+		internal.DetachCapabilitySetsFromRoles(detachCapabilitySetsCommand, enableDebug, false, existingTenant, accessToken)
 	}
 }
 

--- a/eureka-cli/cmd/removeRoles.go
+++ b/eureka-cli/cmd/removeRoles.go
@@ -16,6 +16,7 @@ limitations under the License.
 package cmd
 
 import (
+	"fmt"
 	"log/slog"
 
 	"github.com/folio-org/eureka-cli/internal"
@@ -47,17 +48,17 @@ func RemoveRoles() {
 
 	for _, value := range internal.GetTenants(removeRolesCommand, enableDebug, false) {
 		mapEntry := value.(map[string]interface{})
-		tenant := mapEntry["name"].(string)
 
-		if !internal.HasTenant(tenant) {
+		existingTenant := mapEntry["name"].(string)
+		if !internal.HasTenant(existingTenant) {
 			continue
 		}
 
-		slog.Info(removeRolesCommand, internal.GetFuncName(), "### ACQUIRING KEYCLOAK ACCESS TOKEN ###")
-		accessToken := internal.GetKeycloakAccessToken(removeRolesCommand, enableDebug, vaultRootToken, tenant)
+		slog.Info(removeRolesCommand, internal.GetFuncName(), fmt.Sprintf("### ACQUIRING KEYCLOAK ACCESS TOKEN FOR %s TENANT ###", existingTenant))
+		accessToken := internal.GetKeycloakAccessToken(removeRolesCommand, enableDebug, vaultRootToken, existingTenant)
 
-		slog.Info(removeRolesCommand, internal.GetFuncName(), "### REMOVING ROLES ###")
-		internal.RemoveRoles(removeRolesCommand, enableDebug, false, tenant, accessToken)
+		slog.Info(removeRolesCommand, internal.GetFuncName(), fmt.Sprintf("### REMOVING ROLES FOR %s TENANT ###", existingTenant))
+		internal.RemoveRoles(removeRolesCommand, enableDebug, false, existingTenant, accessToken)
 	}
 }
 

--- a/eureka-cli/cmd/removeUsers.go
+++ b/eureka-cli/cmd/removeUsers.go
@@ -16,6 +16,7 @@ limitations under the License.
 package cmd
 
 import (
+	"fmt"
 	"log/slog"
 
 	"github.com/folio-org/eureka-cli/internal"
@@ -42,17 +43,17 @@ func RemoveUsers() {
 
 	for _, value := range internal.GetTenants(removeUsersCommand, enableDebug, false) {
 		mapEntry := value.(map[string]interface{})
-		tenant := mapEntry["name"].(string)
 
-		if !internal.HasTenant(tenant) {
+		existingTenant := mapEntry["name"].(string)
+		if !internal.HasTenant(existingTenant) {
 			continue
 		}
 
-		slog.Info(removeUsersCommand, internal.GetFuncName(), "### ACQUIRING KEYCLOAK ACCESS TOKEN ###")
-		accessToken := internal.GetKeycloakAccessToken(removeUsersCommand, enableDebug, vaultRootToken, tenant)
+		slog.Info(removeUsersCommand, internal.GetFuncName(), fmt.Sprintf("### ACQUIRING KEYCLOAK ACCESS TOKEN FOR %s TENANT ###", existingTenant))
+		accessToken := internal.GetKeycloakAccessToken(removeUsersCommand, enableDebug, vaultRootToken, existingTenant)
 
-		slog.Info(removeUsersCommand, internal.GetFuncName(), "### REMOVING USERS ###")
-		internal.RemoveUsers(removeUsersCommand, enableDebug, false, tenant, accessToken)
+		slog.Info(removeUsersCommand, internal.GetFuncName(), fmt.Sprintf("### REMOVING USERS FOR %s TENANT ###", existingTenant))
+		internal.RemoveUsers(removeUsersCommand, enableDebug, false, existingTenant, accessToken)
 	}
 }
 

--- a/eureka-cli/cmd/root.go
+++ b/eureka-cli/cmd/root.go
@@ -29,17 +29,18 @@ import (
 const rootCommand string = "Root"
 
 var (
-	configFile   string
-	moduleName   string
-	enableDebug  bool
-	buildImages  bool
-	updateCloned bool
-	tenant       string
-	namespace    string
-	showAll      bool
-	id           string
-	location     string
-	restore      bool
+	configFile        string
+	moduleName        string
+	enableDebug       bool
+	buildImages       bool
+	updateCloned      bool
+	enableEcsRequests bool
+	tenant            string
+	namespace         string
+	showAll           bool
+	id                string
+	location          string
+	restore           bool
 )
 
 // rootCmd represents the base command when called without any subcommands

--- a/eureka-cli/config.acquisitions.yaml
+++ b/eureka-cli/config.acquisitions.yaml
@@ -26,6 +26,8 @@ environment:
   DB_DATABASE: folio
   DB_USERNAME: folio_rw
   DB_PASSWORD: supersecret
+  DB_CHARSET: UTF-8
+  DB_QUERYTIMEOUT: 60000
   # Kafka
   KAFKA_HOST: kafka.eureka
   KAFKA_PORT: 9092
@@ -65,10 +67,10 @@ environment:
   OKAPI_INTEGRATION_ENABLED: false
   WEB_CLIENT_TLS_VERIFY_HOSTNAME: false
   # Java
-  JAVA_OPTIONS: |
+  JAVA_OPTIONS: >-
     -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005 
-    -XX:MaxRAMPercentage=85.0 -Xms128m -Xmx400m 
-    -Djdk.internal.httpclient.disableHostnameVerification=true"
+    -XX:MaxRAMPercentage=70.0 -Xms128m -Xmx400m 
+    -Djdk.internal.httpclient.disableHostnameVerification=true
 # Tenants
 tenants:
   diku:
@@ -81,19 +83,20 @@ sidecar-module:
     SC_LOG_LEVEL: INFO
     ROOT_LOG_LEVEL: INFO
     REQUEST_TIMEOUT: 604800000
-    KC_URL: http://keycloak.eureka:8080
     KC_URI_VALIDATION_ENABLED: false
     ALLOW_CROSS_TENANT_REQUESTS: true
     SIDECAR_FORWARD_UNKNOWN_REQUESTS: true
     QUARKUS_HTTP_LIMITS_MAX_INITIAL_LINE_LENGTH: 8192
-    MOD_USERS_BL: http://mod-users-bl-sc.eureka:8081
-    MOD_USERS_KEYCLOAK_URL: http://mod-users-keycloak-sc.eureka:8081
-    SIDECAR_FORWARD_UNKNOWN_REQUESTS_DESTINATION: http://api-gateway.eureka:8000
-    JAVA_OPTIONS: |
+    JAVA_OPTIONS: >-
       -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005
       -XX:+UseZGC -XX:MaxRAMPercentage=85.0 -Xms64m -Xmx64m
       -Dquarkus.http.host=0.0.0.0 -Dquarkus.log.level=INFO -Dquarkus.log.category.'org.apache.kafka'.level=INFO 
       -Djava.util.logging.manager=org.jboss.logmanager.LogManager
+    # Rancher secret: eureka-common
+    KC_URL: http://keycloak.eureka:8080
+    MOD_USERS_BL: http://mod-users-bl-sc.eureka:8081
+    MOD_USERS_KEYCLOAK_URL: http://mod-users-keycloak-sc.eureka:8081
+    SIDECAR_FORWARD_UNKNOWN_REQUESTS_DESTINATION: http://api-gateway.eureka:8000
 # Backend modules
 backend-modules:
   # Other modules

--- a/eureka-cli/config.acquisitions.yaml
+++ b/eureka-cli/config.acquisitions.yaml
@@ -78,20 +78,21 @@ sidecar-module:
   image: folio-module-sidecar
   environment:
     SIDECAR: true
-    SC_LOG_LEVEL: DEBUG
-    ROOT_LOG_LEVEL: DEBUG
+    SC_LOG_LEVEL: INFO
+    ROOT_LOG_LEVEL: INFO
     REQUEST_TIMEOUT: 604800000
+    KC_URL: http://keycloak.eureka:8080
     KC_URI_VALIDATION_ENABLED: false
     ALLOW_CROSS_TENANT_REQUESTS: true
     SIDECAR_FORWARD_UNKNOWN_REQUESTS: true
     QUARKUS_HTTP_LIMITS_MAX_INITIAL_LINE_LENGTH: 8192
-    MOD_USERS_BL: http://mod-users-bl.eureka:8081
-    MOD_USERS_KEYCLOAK_URL: http://mod-users-keycloak.eureka:8081
+    MOD_USERS_BL: http://mod-users-bl-sc.eureka:8081
+    MOD_USERS_KEYCLOAK_URL: http://mod-users-keycloak-sc.eureka:8081
     SIDECAR_FORWARD_UNKNOWN_REQUESTS_DESTINATION: http://api-gateway.eureka:8000
     JAVA_OPTIONS: |
       -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005
-      -XX:+UseZGC -XX:MaxRAMPercentage=85.0 -Xms50m -Xmx128m
-      -Dquarkus.http.host=0.0.0.0 -Dquarkus.log.level=DEBUG -Dquarkus.log.category.'org.apache.kafka'.level=DEBUG 
+      -XX:+UseZGC -XX:MaxRAMPercentage=85.0 -Xms64m -Xmx64m
+      -Dquarkus.http.host=0.0.0.0 -Dquarkus.log.level=INFO -Dquarkus.log.category.'org.apache.kafka'.level=INFO 
       -Djava.util.logging.manager=org.jboss.logmanager.LogManager
 # Backend modules
 backend-modules:
@@ -151,3 +152,11 @@ frontend-modules:
   folio_plugin-find-organization:
   folio_plugin-find-po-line:
   folio_plugin-find-user:
+# Custom Frontend modules
+custom-frontend-modules:
+  folio_authorization-roles:
+    version: 2.0.109900000000126
+  folio_authorization-policies:
+    version: 2.0.10990000000060
+  folio_plugin-select-application:
+    version: 2.0.10990000000042

--- a/eureka-cli/config.combined.yaml
+++ b/eureka-cli/config.combined.yaml
@@ -101,23 +101,23 @@ users:
 # Sidecar module
 sidecar-module:
   image: folio-module-sidecar
-  version: 2.1.0-SNAPSHOT.164
   environment:
     SIDECAR: true
-    SC_LOG_LEVEL: DEBUG
-    ROOT_LOG_LEVEL: DEBUG
+    SC_LOG_LEVEL: INFO
+    ROOT_LOG_LEVEL: INFO
     REQUEST_TIMEOUT: 604800000
+    KC_URL: http://keycloak.eureka:8080
     KC_URI_VALIDATION_ENABLED: false
     ALLOW_CROSS_TENANT_REQUESTS: true
     SIDECAR_FORWARD_UNKNOWN_REQUESTS: true
     QUARKUS_HTTP_LIMITS_MAX_INITIAL_LINE_LENGTH: 8192
-    MOD_USERS_BL: http://mod-users-bl.eureka:8081
-    MOD_USERS_KEYCLOAK_URL: http://mod-users-keycloak.eureka:8081
+    MOD_USERS_BL: http://mod-users-bl-sc.eureka:8081
+    MOD_USERS_KEYCLOAK_URL: http://mod-users-keycloak-sc.eureka:8081
     SIDECAR_FORWARD_UNKNOWN_REQUESTS_DESTINATION: http://api-gateway.eureka:8000
     JAVA_OPTIONS: |
       -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005
       -XX:+UseZGC -XX:MaxRAMPercentage=85.0 -Xms50m -Xmx128m
-      -Dquarkus.http.host=0.0.0.0 -Dquarkus.log.level=DEBUG -Dquarkus.log.category.'org.apache.kafka'.level=DEBUG 
+      -Dquarkus.http.host=0.0.0.0 -Dquarkus.log.level=INFO -Dquarkus.log.category.'org.apache.kafka'.level=INFO 
       -Djava.util.logging.manager=org.jboss.logmanager.LogManager
 # Backend modules
 backend-modules:
@@ -202,8 +202,8 @@ backend-modules:
       SYSTEM_USER_NAME: mod-consortia-keycloak
       SYSTEM_USER_USERNAME: mod-consortia-keycloak
       # eureka-common
-      MOD_USERS_BL: http://mod-users-bl.eureka:8081
-      MOD_USERS_KEYCLOAK_URL: http://mod-users-keycloak.eureka:8081
+      MOD_USERS_BL: http://mod-users-bl-sc.eureka:8081
+      MOD_USERS_KEYCLOAK_URL: http://mod-users-keycloak-sc.eureka:8081
       # okapi-credentials
       OKAPI_HOST: mod-consortia-keycloak.eureka
       OKAPI_PORT: 8082

--- a/eureka-cli/config.combined.yaml
+++ b/eureka-cli/config.combined.yaml
@@ -25,6 +25,8 @@ environment:
   DB_DATABASE: folio
   DB_USERNAME: folio_rw
   DB_PASSWORD: supersecret
+  DB_CHARSET: UTF-8
+  DB_QUERYTIMEOUT: 60000
   # Kafka
   KAFKA_HOST: kafka.eureka
   KAFKA_PORT: 9092
@@ -64,10 +66,10 @@ environment:
   OKAPI_INTEGRATION_ENABLED: false
   WEB_CLIENT_TLS_VERIFY_HOSTNAME: false
   # Java
-  JAVA_OPTIONS: |
+  JAVA_OPTIONS: >-
     -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005 
     -XX:MaxRAMPercentage=70.0 -Xms128m -Xmx400m 
-    -Djdk.internal.httpclient.disableHostnameVerification=true"
+    -Djdk.internal.httpclient.disableHostnameVerification=true
 # Tenants
 tenants:
   diku:
@@ -76,8 +78,7 @@ tenants:
 roles:
   Admin:
     tenant: diku
-    capability-sets:
-      - all
+    capability-sets: [ "all" ]
   User:
     tenant: diku
     capability-sets: []
@@ -88,16 +89,13 @@ users:
     password: admin
     last-name: John
     first-name: Doe
-    roles:
-      - Admin
-      - User
+    roles: [ "Admin", "User" ] 
   diku_user:
     tenant: diku
     password: user
     last-name: John
     first-name: Smith
-    roles:
-      - User
+    roles: [ "User" ]
 # Sidecar module
 sidecar-module:
   image: folio-module-sidecar
@@ -106,19 +104,20 @@ sidecar-module:
     SC_LOG_LEVEL: INFO
     ROOT_LOG_LEVEL: INFO
     REQUEST_TIMEOUT: 604800000
-    KC_URL: http://keycloak.eureka:8080
     KC_URI_VALIDATION_ENABLED: false
     ALLOW_CROSS_TENANT_REQUESTS: true
     SIDECAR_FORWARD_UNKNOWN_REQUESTS: true
     QUARKUS_HTTP_LIMITS_MAX_INITIAL_LINE_LENGTH: 8192
-    MOD_USERS_BL: http://mod-users-bl-sc.eureka:8081
-    MOD_USERS_KEYCLOAK_URL: http://mod-users-keycloak-sc.eureka:8081
-    SIDECAR_FORWARD_UNKNOWN_REQUESTS_DESTINATION: http://api-gateway.eureka:8000
-    JAVA_OPTIONS: |
+    JAVA_OPTIONS: >-
       -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005
       -XX:+UseZGC -XX:MaxRAMPercentage=85.0 -Xms64m -Xmx64m
       -Dquarkus.http.host=0.0.0.0 -Dquarkus.log.level=INFO -Dquarkus.log.category.'org.apache.kafka'.level=INFO 
       -Djava.util.logging.manager=org.jboss.logmanager.LogManager
+    # Rancher secret: eureka-common
+    KC_URL: http://keycloak.eureka:8080
+    MOD_USERS_BL: http://mod-users-bl-sc.eureka:8081
+    MOD_USERS_KEYCLOAK_URL: http://mod-users-keycloak-sc.eureka:8081
+    SIDECAR_FORWARD_UNKNOWN_REQUESTS_DESTINATION: http://api-gateway.eureka:8000
 # Backend modules
 backend-modules:
   # Management modules
@@ -167,7 +166,7 @@ backend-modules:
     environment:
       OKAPI_URL: http://mod-users-keycloak-sc.eureka:8081
       INCLUDE_ONLY_VISIBLE_PERMISSIONS: 'false'
-      MOD_USERS_URL: http://mod-users.eureka
+      # Rancher secret: mod-users-keycloak-systemuser
       FOLIO_SYSTEM_USER_ENABLED: 'false'
       SYSTEM_USER_CREATE: 'false'
       SYSTEM_USER_ENABLED: 'false'
@@ -185,6 +184,7 @@ backend-modules:
     port: 9907
     sidecar: true
     environment:
+      # Rancher secret: mod-scheduler-systemuser
       FOLIO_SYSTEM_USER_ENABLED: 'false'
       SYSTEM_USER_CREATE: 'false'
       SYSTEM_USER_ENABLED: 'false'
@@ -196,15 +196,16 @@ backend-modules:
     port: 9908
     sidecar: true
     environment:
+      # Rancher secret: mod-consortia-keycloak-systemuser
       FOLIO_SYSTEM_USER_ENABLED: 'false'
       SYSTEM_USER_CREATE: 'false'
       SYSTEM_USER_ENABLED: 'false'
       SYSTEM_USER_NAME: mod-consortia-keycloak
       SYSTEM_USER_USERNAME: mod-consortia-keycloak
-      # eureka-common
+      # Rancher secret: eureka-common
       MOD_USERS_BL: http://mod-users-bl-sc.eureka:8081
       MOD_USERS_KEYCLOAK_URL: http://mod-users-keycloak-sc.eureka:8081
-      # okapi-credentials
+      # Rancher secret: okapi-credentials
       OKAPI_HOST: mod-consortia-keycloak.eureka
       OKAPI_PORT: 8082
       OKAPI_SERVICE_HOST: mod-consortia-keycloak.eureka
@@ -234,6 +235,7 @@ backend-modules:
   mod-audit:
   mod-pubsub:
     environment:
+      # Rancher secret: mod-pubsub-systemuser
       FOLIO_SYSTEM_USER_ENABLED: 'false'
       SYSTEM_USER_CREATE: 'false'
       SYSTEM_USER_ENABLED: 'false'
@@ -246,6 +248,7 @@ backend-modules:
   mod-search:
     deploy-module: false
     environment:
+      # Rancher secret: mod-search-systemuser
       FOLIO_SYSTEM_USER_ENABLED: 'false'
       SYSTEM_USER_CREATE: 'false'
       SYSTEM_USER_ENABLED: 'false'

--- a/eureka-cli/config.combined.yaml
+++ b/eureka-cli/config.combined.yaml
@@ -116,7 +116,7 @@ sidecar-module:
     SIDECAR_FORWARD_UNKNOWN_REQUESTS_DESTINATION: http://api-gateway.eureka:8000
     JAVA_OPTIONS: |
       -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005
-      -XX:+UseZGC -XX:MaxRAMPercentage=85.0 -Xms50m -Xmx128m
+      -XX:+UseZGC -XX:MaxRAMPercentage=85.0 -Xms64m -Xmx64m
       -Dquarkus.http.host=0.0.0.0 -Dquarkus.log.level=INFO -Dquarkus.log.category.'org.apache.kafka'.level=INFO 
       -Djava.util.logging.manager=org.jboss.logmanager.LogManager
 # Backend modules

--- a/eureka-cli/config.combined.yaml
+++ b/eureka-cli/config.combined.yaml
@@ -101,6 +101,7 @@ users:
 # Sidecar module
 sidecar-module:
   image: folio-module-sidecar
+  version: 2.1.0-SNAPSHOT.164
   environment:
     SIDECAR: true
     SC_LOG_LEVEL: DEBUG

--- a/eureka-cli/config.combined.yaml
+++ b/eureka-cli/config.combined.yaml
@@ -200,6 +200,15 @@ backend-modules:
       SYSTEM_USER_ENABLED: 'false'
       SYSTEM_USER_NAME: mod-consortia-keycloak
       SYSTEM_USER_USERNAME: mod-consortia-keycloak
+      # eureka-common
+      MOD_USERS_BL: http://mod-users-bl.eureka:8081
+      MOD_USERS_KEYCLOAK_URL: http://mod-users-keycloak.eureka:8081
+      # okapi-credentials
+      OKAPI_HOST: mod-consortia-keycloak.eureka
+      OKAPI_PORT: 8082
+      OKAPI_SERVICE_HOST: mod-consortia-keycloak.eureka
+      OKAPI_SERVICE_URL: http://mod-consortia-keycloak.eureka:8082
+      OKAPI_URL: http://mod-consortia-keycloak.eureka:8082
   # Core Modules
   mod-permissions:
   mod-configuration:
@@ -268,8 +277,8 @@ frontend-modules:
 # Custom Frontend modules
 custom-frontend-modules:
   folio_authorization-roles:
-    version: 1.6.10990000000025
+    version: 2.0.109900000000126
   folio_authorization-policies:
-    version: 1.3.10990000000015
+    version: 2.0.10990000000060
   folio_plugin-select-application:
-    version: 1.1.1099000000003
+    version: 2.0.10990000000042

--- a/eureka-cli/config.export.yaml
+++ b/eureka-cli/config.export.yaml
@@ -1,0 +1,139 @@
+# Profile
+profile:
+  name: export
+# Application
+application:
+  name: app-export
+  version: 1.0.0
+  platform: base
+  fetch-descriptors: false
+  port-start: 35000
+  dependencies:
+    name: app-combined
+    version: 1.0.0
+# Registry
+registry:
+  registry-url: https://folio-registry.dev.folio.org
+  folio-install-json-url: https://raw.githubusercontent.com/folio-org/platform-complete/snapshot/install.json
+  eureka-install-json-url: https://raw.githubusercontent.com/folio-org/platform-complete/snapshot/eureka-platform.json
+  namespaces:
+    platform-complete-ui: bkadirkhodjaev
+# Environment
+environment:
+  # General
+  ENV: folio
+  # PostgreSQL
+  DB_HOST: postgres.eureka
+  DB_PORT: 5432
+  DB_DATABASE: folio
+  DB_USERNAME: folio_rw
+  DB_PASSWORD: supersecret
+  # Kafka
+  KAFKA_HOST: kafka.eureka
+  KAFKA_PORT: 9092
+  # Elasticsearch
+  ELASTICSEARCH_URL: http://host.docker.internal:9200
+  # AWS S3/MinIO
+  AWS_URL: http://host.docker.internal:9000
+  AWS_REGION: us-east-1
+  AWS_BUCKET: example-bucket
+  AWS_ACCESS_KEY_ID: minioadmin
+  AWS_SECRET_ACCESS_KEY: minioadmin
+  S3_IS_AWS: false
+  S3_URL: http://host.docker.internal:9000
+  S3_REGION: us-east-1
+  S3_ACCESS_KEY_ID: minioadmin
+  S3_SECRET_ACCESS_KEY: minioadmin
+  S3_BUCKET: example-bucket
+  SPLIT_FILES_ENABLED: true
+  # Consortia
+  SYSTEM_USER_PASSWORD: system_user_password
+  # Management
+  MT_URL: http://mgr-tenants.eureka:8081
+  AM_CLIENT_URL: http://mgr-applications.eureka:8081
+  KONG_ADMIN_URL: http://api-gateway.eureka:8001
+  # Keycloak
+  KC_URL: http://keycloak.eureka:8080
+  KC_CONFIG_TTL: 3600s
+  KC_ADMIN_CLIENT_ID: supersecret
+  KC_ADMIN_USERNAME: admin
+  KC_ADMIN_PASSWORD: admin
+  SECURITY_ENABLED: false
+  KC_IMPORT_ENABLED: true
+  KC_INTEGRATION_ENABLED: true
+  KC_LOGIN_CLIENT_SUFFIX: -application
+  KC_SERVICE_CLIENT_ID: sidecar-module-access-client
+  KONG_INTEGRATION_ENABLED: true
+  OKAPI_INTEGRATION_ENABLED: false
+  WEB_CLIENT_TLS_VERIFY_HOSTNAME: false
+  # Java
+  JAVA_OPTIONS: |
+    -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005 
+    -XX:MaxRAMPercentage=70.0 -Xms128m -Xmx400m 
+    -Djdk.internal.httpclient.disableHostnameVerification=true"
+# Tenants
+tenants:
+  diku:
+    deploy-ui: false
+# Roles
+roles:
+  Admin:
+    tenant: diku
+    capability-sets:
+      - all
+  User:
+    tenant: diku
+    capability-sets: []
+# Users
+users:
+  diku_admin:
+    tenant: diku
+    password: admin
+    last-name: John
+    first-name: Doe
+    roles:
+      - Admin
+      - User
+  diku_user:
+    tenant: diku
+    password: user
+    last-name: John
+    first-name: Smith
+    roles:
+      - User
+# Sidecar module
+sidecar-module:
+  image: folio-module-sidecar
+  environment:
+    SIDECAR: true
+    SC_LOG_LEVEL: DEBUG
+    ROOT_LOG_LEVEL: DEBUG
+    REQUEST_TIMEOUT: 604800000
+    KC_URI_VALIDATION_ENABLED: false
+    ALLOW_CROSS_TENANT_REQUESTS: true
+    SIDECAR_FORWARD_UNKNOWN_REQUESTS: true
+    QUARKUS_HTTP_LIMITS_MAX_INITIAL_LINE_LENGTH: 8192
+    MOD_USERS_BL: http://mod-users-bl.eureka:8081
+    MOD_USERS_KEYCLOAK_URL: http://mod-users-keycloak.eureka:8081
+    SIDECAR_FORWARD_UNKNOWN_REQUESTS_DESTINATION: http://api-gateway.eureka:8000
+    JAVA_OPTIONS: |
+      -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005
+      -XX:+UseZGC -XX:MaxRAMPercentage=85.0 -Xms50m -Xmx128m
+      -Dquarkus.http.host=0.0.0.0 -Dquarkus.log.level=DEBUG -Dquarkus.log.category.'org.apache.kafka'.level=DEBUG 
+      -Djava.util.logging.manager=org.jboss.logmanager.LogManager
+# Backend modules
+backend-modules:
+  mod-data-export-spring:
+    environment:
+      FOLIO_SYSTEM_USER_ENABLED: 'false'
+      SYSTEM_USER_CREATE: 'false'
+      SYSTEM_USER_ENABLED: 'false'
+      SYSTEM_USER_NAME: mod-data-export-spring
+      SYSTEM_USER_USERNAME: mod-data-export-spring
+  mod-data-export-worker:
+# Frontend modules
+frontend-modules:
+  folio_data-export:
+  folio_export-manager:
+  folio_plugin-bursar-export:
+

--- a/eureka-cli/config.export.yaml
+++ b/eureka-cli/config.export.yaml
@@ -28,6 +28,8 @@ environment:
   DB_DATABASE: folio
   DB_USERNAME: folio_rw
   DB_PASSWORD: supersecret
+  DB_CHARSET: UTF-8
+  DB_QUERYTIMEOUT: 60000
   # Kafka
   KAFKA_HOST: kafka.eureka
   KAFKA_PORT: 9092
@@ -67,10 +69,10 @@ environment:
   OKAPI_INTEGRATION_ENABLED: false
   WEB_CLIENT_TLS_VERIFY_HOSTNAME: false
   # Java
-  JAVA_OPTIONS: |
+  JAVA_OPTIONS: >-
     -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005 
     -XX:MaxRAMPercentage=70.0 -Xms128m -Xmx400m 
-    -Djdk.internal.httpclient.disableHostnameVerification=true"
+    -Djdk.internal.httpclient.disableHostnameVerification=true
 # Tenants
 tenants:
   diku:
@@ -79,8 +81,7 @@ tenants:
 roles:
   Admin:
     tenant: diku
-    capability-sets:
-      - all
+    capability-sets: [ "all" ]
   User:
     tenant: diku
     capability-sets: []
@@ -91,16 +92,13 @@ users:
     password: admin
     last-name: John
     first-name: Doe
-    roles:
-      - Admin
-      - User
+    roles: [ "Admin", "User" ] 
   diku_user:
     tenant: diku
     password: user
     last-name: John
     first-name: Smith
-    roles:
-      - User
+    roles: [ "User" ]
 # Sidecar module
 sidecar-module:
   image: folio-module-sidecar
@@ -109,29 +107,30 @@ sidecar-module:
     SC_LOG_LEVEL: INFO
     ROOT_LOG_LEVEL: INFO
     REQUEST_TIMEOUT: 604800000
-    KC_URL: http://keycloak.eureka:8080
     KC_URI_VALIDATION_ENABLED: false
     ALLOW_CROSS_TENANT_REQUESTS: true
     SIDECAR_FORWARD_UNKNOWN_REQUESTS: true
     QUARKUS_HTTP_LIMITS_MAX_INITIAL_LINE_LENGTH: 8192
-    MOD_USERS_BL: http://mod-users-bl-sc.eureka:8081
-    MOD_USERS_KEYCLOAK_URL: http://mod-users-keycloak-sc.eureka:8081
-    SIDECAR_FORWARD_UNKNOWN_REQUESTS_DESTINATION: http://api-gateway.eureka:8000
-    JAVA_OPTIONS: |
+    JAVA_OPTIONS: >-
       -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005
       -XX:+UseZGC -XX:MaxRAMPercentage=85.0 -Xms64m -Xmx64m
       -Dquarkus.http.host=0.0.0.0 -Dquarkus.log.level=INFO -Dquarkus.log.category.'org.apache.kafka'.level=INFO 
       -Djava.util.logging.manager=org.jboss.logmanager.LogManager
+    # Rancher secret: eureka-common
+    KC_URL: http://keycloak.eureka:8080
+    MOD_USERS_BL: http://mod-users-bl-sc.eureka:8081
+    MOD_USERS_KEYCLOAK_URL: http://mod-users-keycloak-sc.eureka:8081
+    SIDECAR_FORWARD_UNKNOWN_REQUESTS_DESTINATION: http://api-gateway.eureka:8000
 # Backend modules
 backend-modules:
   mod-data-export-spring:
     environment:
+      # Rancher secret: mod-data-export-spring-systemuser
       FOLIO_SYSTEM_USER_ENABLED: 'false'
       SYSTEM_USER_CREATE: 'false'
       SYSTEM_USER_ENABLED: 'false'
       SYSTEM_USER_NAME: mod-data-export-spring
       SYSTEM_USER_USERNAME: mod-data-export-spring
-  mod-data-export-worker:
 # Frontend modules
 frontend-modules:
   folio_data-export:

--- a/eureka-cli/config.export.yaml
+++ b/eureka-cli/config.export.yaml
@@ -106,20 +106,21 @@ sidecar-module:
   image: folio-module-sidecar
   environment:
     SIDECAR: true
-    SC_LOG_LEVEL: DEBUG
-    ROOT_LOG_LEVEL: DEBUG
+    SC_LOG_LEVEL: INFO
+    ROOT_LOG_LEVEL: INFO
     REQUEST_TIMEOUT: 604800000
+    KC_URL: http://keycloak.eureka:8080
     KC_URI_VALIDATION_ENABLED: false
     ALLOW_CROSS_TENANT_REQUESTS: true
     SIDECAR_FORWARD_UNKNOWN_REQUESTS: true
     QUARKUS_HTTP_LIMITS_MAX_INITIAL_LINE_LENGTH: 8192
-    MOD_USERS_BL: http://mod-users-bl.eureka:8081
-    MOD_USERS_KEYCLOAK_URL: http://mod-users-keycloak.eureka:8081
+    MOD_USERS_BL: http://mod-users-bl-sc.eureka:8081
+    MOD_USERS_KEYCLOAK_URL: http://mod-users-keycloak-sc.eureka:8081
     SIDECAR_FORWARD_UNKNOWN_REQUESTS_DESTINATION: http://api-gateway.eureka:8000
     JAVA_OPTIONS: |
       -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005
-      -XX:+UseZGC -XX:MaxRAMPercentage=85.0 -Xms50m -Xmx128m
-      -Dquarkus.http.host=0.0.0.0 -Dquarkus.log.level=DEBUG -Dquarkus.log.category.'org.apache.kafka'.level=DEBUG 
+      -XX:+UseZGC -XX:MaxRAMPercentage=85.0 -Xms64m -Xmx64m
+      -Dquarkus.http.host=0.0.0.0 -Dquarkus.log.level=INFO -Dquarkus.log.category.'org.apache.kafka'.level=INFO 
       -Djava.util.logging.manager=org.jboss.logmanager.LogManager
 # Backend modules
 backend-modules:

--- a/eureka-cli/config.minimal.yaml
+++ b/eureka-cli/config.minimal.yaml
@@ -103,20 +103,21 @@ sidecar-module:
   image: folio-module-sidecar
   environment:
     SIDECAR: true
-    SC_LOG_LEVEL: DEBUG
-    ROOT_LOG_LEVEL: DEBUG
+    SC_LOG_LEVEL: INFO
+    ROOT_LOG_LEVEL: INFO
     REQUEST_TIMEOUT: 604800000
+    KC_URL: http://keycloak.eureka:8080
     KC_URI_VALIDATION_ENABLED: false
     ALLOW_CROSS_TENANT_REQUESTS: true
     SIDECAR_FORWARD_UNKNOWN_REQUESTS: true
     QUARKUS_HTTP_LIMITS_MAX_INITIAL_LINE_LENGTH: 8192
-    MOD_USERS_BL: http://mod-users-bl.eureka:8081
-    MOD_USERS_KEYCLOAK_URL: http://mod-users-keycloak.eureka:8081
+    MOD_USERS_BL: http://mod-users-bl-sc.eureka:8081
+    MOD_USERS_KEYCLOAK_URL: http://mod-users-keycloak-sc.eureka:8081
     SIDECAR_FORWARD_UNKNOWN_REQUESTS_DESTINATION: http://api-gateway.eureka:8000
     JAVA_OPTIONS: |
       -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005
-      -XX:+UseZGC -XX:MaxRAMPercentage=85.0 -Xms50m -Xmx128m
-      -Dquarkus.http.host=0.0.0.0 -Dquarkus.log.level=DEBUG -Dquarkus.log.category.'org.apache.kafka'.level=DEBUG 
+      -XX:+UseZGC -XX:MaxRAMPercentage=85.0 -Xms64m -Xmx64m
+      -Dquarkus.http.host=0.0.0.0 -Dquarkus.log.level=INFO -Dquarkus.log.category.'org.apache.kafka'.level=INFO 
       -Djava.util.logging.manager=org.jboss.logmanager.LogManager
 # Backend modules
 backend-modules:
@@ -212,8 +213,8 @@ backend-modules:
   mod-tags:
 # Frontend modules
 frontend-modules:
-  folio_developer:
   folio_stripes-core:
+  folio_developer:
   folio_notes:
   folio_tags:
   folio_stripes-smart-components:
@@ -221,8 +222,8 @@ frontend-modules:
 # Custom Frontend modules
 custom-frontend-modules:
   folio_authorization-roles:
-    version: 1.6.10990000000025
+    version: 2.0.109900000000126
   folio_authorization-policies:
-    version: 1.3.10990000000015
+    version: 2.0.10990000000060
   folio_plugin-select-application:
-    version: 1.1.1099000000003
+    version: 2.0.10990000000042

--- a/eureka-cli/config.minimal.yaml
+++ b/eureka-cli/config.minimal.yaml
@@ -25,6 +25,8 @@ environment:
   DB_DATABASE: folio
   DB_USERNAME: folio_rw
   DB_PASSWORD: supersecret
+  DB_CHARSET: UTF-8
+  DB_QUERYTIMEOUT: 60000
   # Kafka
   KAFKA_HOST: kafka.eureka
   KAFKA_PORT: 9092
@@ -64,10 +66,10 @@ environment:
   OKAPI_INTEGRATION_ENABLED: false
   WEB_CLIENT_TLS_VERIFY_HOSTNAME: false
   # Java
-  JAVA_OPTIONS: |
+  JAVA_OPTIONS: >-
     -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005 
     -XX:MaxRAMPercentage=70.0 -Xms128m -Xmx400m 
-    -Djdk.internal.httpclient.disableHostnameVerification=true"
+    -Djdk.internal.httpclient.disableHostnameVerification=true
 # Tenants
 tenants:
   diku:
@@ -76,8 +78,7 @@ tenants:
 roles:
   Admin:
     tenant: diku
-    capability-sets:
-      - all
+    capability-sets: [ "all" ]
   User:
     tenant: diku
     capability-sets: []
@@ -88,16 +89,13 @@ users:
     password: admin
     last-name: John
     first-name: Doe
-    roles:
-      - Admin
-      - User
+    roles: [ "Admin", "User" ] 
   diku_user:
     tenant: diku
     password: user
     last-name: John
     first-name: Smith
-    roles:
-      - User
+    roles: [ "User" ]
 # Sidecar module
 sidecar-module:
   image: folio-module-sidecar
@@ -106,19 +104,20 @@ sidecar-module:
     SC_LOG_LEVEL: INFO
     ROOT_LOG_LEVEL: INFO
     REQUEST_TIMEOUT: 604800000
-    KC_URL: http://keycloak.eureka:8080
     KC_URI_VALIDATION_ENABLED: false
     ALLOW_CROSS_TENANT_REQUESTS: true
     SIDECAR_FORWARD_UNKNOWN_REQUESTS: true
     QUARKUS_HTTP_LIMITS_MAX_INITIAL_LINE_LENGTH: 8192
-    MOD_USERS_BL: http://mod-users-bl-sc.eureka:8081
-    MOD_USERS_KEYCLOAK_URL: http://mod-users-keycloak-sc.eureka:8081
-    SIDECAR_FORWARD_UNKNOWN_REQUESTS_DESTINATION: http://api-gateway.eureka:8000
-    JAVA_OPTIONS: |
+    JAVA_OPTIONS: >-
       -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005
       -XX:+UseZGC -XX:MaxRAMPercentage=85.0 -Xms64m -Xmx64m
       -Dquarkus.http.host=0.0.0.0 -Dquarkus.log.level=INFO -Dquarkus.log.category.'org.apache.kafka'.level=INFO 
       -Djava.util.logging.manager=org.jboss.logmanager.LogManager
+    # Rancher secret: eureka-common
+    KC_URL: http://keycloak.eureka:8080
+    MOD_USERS_BL: http://mod-users-bl-sc.eureka:8081
+    MOD_USERS_KEYCLOAK_URL: http://mod-users-keycloak-sc.eureka:8081
+    SIDECAR_FORWARD_UNKNOWN_REQUESTS_DESTINATION: http://api-gateway.eureka:8000
 # Backend modules
 backend-modules:
   # Management modules
@@ -167,7 +166,7 @@ backend-modules:
     environment:
       OKAPI_URL: http://mod-users-keycloak-sc.eureka:8081
       INCLUDE_ONLY_VISIBLE_PERMISSIONS: 'false'
-      MOD_USERS_URL: http://mod-users.eureka
+      # Rancher secret: mod-users-keycloak-systemuser
       FOLIO_SYSTEM_USER_ENABLED: 'false'
       SYSTEM_USER_CREATE: 'false'
       SYSTEM_USER_ENABLED: 'false'
@@ -185,6 +184,7 @@ backend-modules:
     port: 9907
     sidecar: true
     environment:
+      # Rancher secret: mod-scheduler-systemuser
       FOLIO_SYSTEM_USER_ENABLED: 'false'
       SYSTEM_USER_CREATE: 'false'
       SYSTEM_USER_ENABLED: 'false'
@@ -196,11 +196,21 @@ backend-modules:
     port: 9908
     sidecar: true
     environment:
+      # Rancher secret: mod-consortia-keycloak-systemuser
       FOLIO_SYSTEM_USER_ENABLED: 'false'
       SYSTEM_USER_CREATE: 'false'
       SYSTEM_USER_ENABLED: 'false'
       SYSTEM_USER_NAME: mod-consortia-keycloak
       SYSTEM_USER_USERNAME: mod-consortia-keycloak
+      # Rancher secret: eureka-common
+      MOD_USERS_BL: http://mod-users-bl-sc.eureka:8081
+      MOD_USERS_KEYCLOAK_URL: http://mod-users-keycloak-sc.eureka:8081
+      # Rancher secret: okapi-credentials
+      OKAPI_HOST: mod-consortia-keycloak.eureka
+      OKAPI_PORT: 8082
+      OKAPI_SERVICE_HOST: mod-consortia-keycloak.eureka
+      OKAPI_SERVICE_URL: http://mod-consortia-keycloak.eureka:8082
+      OKAPI_URL: http://mod-consortia-keycloak.eureka:8082
   # Core Modules
   mod-permissions:
   mod-configuration:

--- a/eureka-cli/internal/management.go
+++ b/eureka-cli/internal/management.go
@@ -237,7 +237,7 @@ func CreateApplications(commandName string, enableDebug bool, dto *RegisterModul
 		panic(err)
 	}
 
-	DoPostReturnNoContent(commandName, fmt.Sprintf(GetGatewayHostname(), ApplicationsPort, "/applications?check=true"), enableDebug, applicationBytes, map[string]string{})
+	DoPostReturnNoContent(commandName, fmt.Sprintf(GetGatewayHostname(), ApplicationsPort, "/applications?check=true"), enableDebug, true, applicationBytes, map[string]string{})
 
 	slog.Info(commandName, GetFuncName(), fmt.Sprintf(`Created %s application`, applicationId))
 
@@ -248,7 +248,7 @@ func CreateApplications(commandName string, enableDebug bool, dto *RegisterModul
 			panic(err)
 		}
 
-		DoPostReturnNoContent(commandName, fmt.Sprintf(GetGatewayHostname(), ApplicationsPort, "/modules/discovery"), enableDebug, applicationDiscoveryBytes, map[string]string{})
+		DoPostReturnNoContent(commandName, fmt.Sprintf(GetGatewayHostname(), ApplicationsPort, "/modules/discovery"), enableDebug, true, applicationDiscoveryBytes, map[string]string{})
 	}
 
 	slog.Info(commandName, GetFuncName(), fmt.Sprintf(`Created %d entries of application module discovery`, len(discoveryModules)))
@@ -319,7 +319,7 @@ func CreateTenants(commandName string, enableDebug bool) {
 			panic(err)
 		}
 
-		DoPostReturnNoContent(commandName, requestUrl, enableDebug, tenantBytes, map[string]string{})
+		DoPostReturnNoContent(commandName, requestUrl, enableDebug, true, tenantBytes, map[string]string{})
 
 		slog.Info(commandName, GetFuncName(), fmt.Sprintf(`Created %s tenant (realm)`, tenant))
 	}
@@ -358,7 +358,6 @@ func RemoveTenantEntitlements(commandName string, enableDebug bool, panicOnError
 	}
 }
 
-// TODO Add depCheck=false flag
 func CreateTenantEntitlement(commandName string, enableDebug bool) {
 	requestUrl := fmt.Sprintf(GetGatewayHostname(), TenantEntitlementsPort, "/entitlements?purgeOnRollback=true&ignoreErrors=false&tenantParameters=loadReference=true,loadSample=true")
 	applicationMap := viper.GetStringMap(ApplicationKey)
@@ -384,7 +383,7 @@ func CreateTenantEntitlement(commandName string, enableDebug bool) {
 			panic(err)
 		}
 
-		DoPostReturnNoContent(commandName, requestUrl, enableDebug, tenantEntitlementBytes, map[string]string{})
+		DoPostReturnNoContent(commandName, requestUrl, enableDebug, true, tenantEntitlementBytes, map[string]string{})
 
 		slog.Info(commandName, GetFuncName(), fmt.Sprintf(`Created tenant entitlement for %s tenant (realm)`, tenant))
 	}
@@ -427,7 +426,7 @@ func RemoveUsers(commandName string, enableDebug bool, panicOnError bool, tenant
 	}
 }
 
-func CreateUsers(commandName string, enableDebug bool, accessToken string) {
+func CreateUsers(commandName string, enableDebug bool, panicOnError bool, existingTenant string, accessToken string) {
 	postUserRequestUrl := fmt.Sprintf(GetGatewayHostname(), GatewayPort, "/users-keycloak/users")
 	postUserPasswordRequestUrl := fmt.Sprintf(GetGatewayHostname(), GatewayPort, "/authn/credentials")
 	postUserRoleRequestUrl := fmt.Sprintf(GetGatewayHostname(), GatewayPort, "/roles/users")
@@ -436,6 +435,10 @@ func CreateUsers(commandName string, enableDebug bool, accessToken string) {
 	for username, value := range usersMap {
 		mapEntry := value.(map[string]interface{})
 		tenant := mapEntry["tenant"].(string)
+		if existingTenant != tenant {
+			continue
+		}
+
 		password := mapEntry["password"].(string)
 		firstName := mapEntry["first-name"].(string)
 		lastName := mapEntry["last-name"].(string)
@@ -460,7 +463,7 @@ func CreateUsers(commandName string, enableDebug bool, accessToken string) {
 		okapiBasedHeaders := map[string]string{ContentTypeHeader: JsonContentType, TenantHeader: tenant, TokenHeader: accessToken}
 		nonOkapiBasedHeaders := map[string]string{ContentTypeHeader: JsonContentType, TenantHeader: tenant, AuthorizationHeader: fmt.Sprintf("Bearer %s", accessToken)}
 
-		createdUserMap := DoPostReturnMapStringInteface(commandName, postUserRequestUrl, enableDebug, userBytes, okapiBasedHeaders)
+		createdUserMap := DoPostReturnMapStringInteface(commandName, postUserRequestUrl, enableDebug, panicOnError, userBytes, okapiBasedHeaders)
 
 		userId := createdUserMap["id"].(string)
 
@@ -472,7 +475,7 @@ func CreateUsers(commandName string, enableDebug bool, accessToken string) {
 			panic(err)
 		}
 
-		DoPostReturnNoContent(commandName, postUserPasswordRequestUrl, enableDebug, userPasswordBytes, nonOkapiBasedHeaders)
+		DoPostReturnNoContent(commandName, postUserPasswordRequestUrl, enableDebug, panicOnError, userPasswordBytes, nonOkapiBasedHeaders)
 
 		slog.Info(commandName, GetFuncName(), fmt.Sprintf(`Attached %s password to %s user in %s tenant (realm)`, password, username, tenant))
 
@@ -496,7 +499,7 @@ func CreateUsers(commandName string, enableDebug bool, accessToken string) {
 			panic(err)
 		}
 
-		DoPostReturnNoContent(commandName, postUserRoleRequestUrl, enableDebug, userRoleBytes, okapiBasedHeaders)
+		DoPostReturnNoContent(commandName, postUserRoleRequestUrl, enableDebug, panicOnError, userRoleBytes, okapiBasedHeaders)
 
 		slog.Info(commandName, GetFuncName(), fmt.Sprintf(`Attached %d roles to %s user in %s tenant (realm)`, len(roleIds), username, tenant))
 	}
@@ -556,14 +559,18 @@ func RemoveRoles(commandName string, enableDebug bool, panicOnError bool, tenant
 	}
 }
 
-func CreateRoles(commandName string, enableDebug bool, accessToken string) {
+func CreateRoles(commandName string, enableDebug bool, panicOnError bool, existingTenant string, accessToken string) {
 	requestUrl := fmt.Sprintf(GetGatewayHostname(), GatewayPort, "/roles")
 	rolesMap := viper.GetStringMap(RolesKey)
+	caser := cases.Title(language.English)
 
 	for role, value := range rolesMap {
 		mapEntry := value.(map[string]interface{})
 		tenant := mapEntry["tenant"].(string)
-		caser := cases.Title(language.English)
+		if existingTenant != tenant {
+			continue
+		}
+
 		headers := map[string]string{ContentTypeHeader: JsonContentType, TenantHeader: tenant, TokenHeader: accessToken}
 
 		roleBytes, err := json.Marshal(map[string]string{"name": caser.String(role), "description": "Default"})
@@ -572,7 +579,7 @@ func CreateRoles(commandName string, enableDebug bool, accessToken string) {
 			panic(err)
 		}
 
-		DoPostReturnNoContent(commandName, requestUrl, enableDebug, roleBytes, headers)
+		DoPostReturnNoContent(commandName, requestUrl, enableDebug, panicOnError, roleBytes, headers)
 
 		slog.Info(commandName, GetFuncName(), fmt.Sprintf(`Created %s role in %s tenant (realm)`, role, tenant))
 	}
@@ -688,7 +695,7 @@ func AttachCapabilitySetsToRoles(commandName string, enableDebug bool, tenant st
 			panic(err)
 		}
 
-		DoPostReturnNoContent(commandName, requestUrl, enableDebug, capabilitySetsBytes, headers)
+		DoPostReturnNoContent(commandName, requestUrl, enableDebug, true, capabilitySetsBytes, headers)
 
 		slog.Info(commandName, GetFuncName(), fmt.Sprintf(`Attached %d capability sets to %s role in %s tenant (realm)`, len(capabilitySetIds), roleName, tenant))
 	}

--- a/eureka-cli/internal/util.go
+++ b/eureka-cli/internal/util.go
@@ -70,8 +70,8 @@ func DumpHttpResponse(commandName string, resp *http.Response, enableDebug bool)
 	fmt.Println()
 }
 
-func CheckStatusCodes(commandName string, resp *http.Response) {
-	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+func CheckStatusCodes(commandName string, panicOnError bool, resp *http.Response) {
+	if !panicOnError || resp.StatusCode >= 200 && resp.StatusCode < 300 {
 		return
 	}
 

--- a/eureka-cli/misc/docker-compose.yaml
+++ b/eureka-cli/misc/docker-compose.yaml
@@ -170,6 +170,9 @@ services:
       KC_HOSTNAME_STRICT: true
       KC_HOSTNAME_STRICT_HTTPS: false
       JAVA_OPTS_APPEND: "-Xms768m -Xmx1024m"
+      KC_LOG_LEVEL: INFO
+      DEBUG: true
+      DEBUG_PORT: '*:8787'
     depends_on:
       postgres:
         condition: service_healthy
@@ -179,6 +182,7 @@ services:
       - fpm-net
     ports:
       - "18081:8080"
+      - "18787:8787"
     deploy:
       resources:
         limits:


### PR DESCRIPTION
## Purpose

- Improve exception handling, add improved tenant checks, bump UI module versions

## Approach

- Improve exception handling by silencing thread panicking during a failed HTTP request conditionally
- Improve tenant checks by simplifying the code and making it more streamlined
- Update UI module versions to the latest snapshot version to resolve some issues during the Application creation phase
- Also add an Export config that can be entitled separately after the Combined is deployed, to test export modules
- Fix issue with `X-Okapi-Permissions` being null due to an incorrect URL pointing to mod-users-keycloak
- Reduce sidecar JVM memory usage
  - In accordance with the newly introduced changes: <https://github.com/folio-org/folio-module-sidecar/pull/182>
