### PR TITLE
KEYCLOAK-53: Rename deprecated KEYCLOAK_ADMIN/KEYCLOAK_ADMIN_PASSWORD

### DIFF
--- a/eureka-cli/misc/docker-compose.yaml
+++ b/eureka-cli/misc/docker-compose.yaml
@@ -179,8 +179,8 @@ services:
       vault:
         condition: service_healthy
     environment:
-      KEYCLOAK_ADMIN: admin
-      KEYCLOAK_ADMIN_PASSWORD: admin
+      KC_BOOTSTRAP_ADMIN_USERNAME: admin
+      KC_BOOTSTRAP_ADMIN_PASSWORD: admin
       KC_FOLIO_BE_ADMIN_CLIENT_ID: supersecret
       KC_FOLIO_BE_ADMIN_CLIENT_SECRET: supersecret
       KC_DB_URL_HOST: postgres.eureka


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/KEYCLOAK-53

Purpose

Rename deprecated KEYCLOAK_ADMIN/KEYCLOAK_ADMIN_PASSWORD environment variables.

Approach

Rename KEYCLOAK_ADMIN to KC_BOOTSTRAP_ADMIN_USERNAME.

Rename KEYCLOAK_ADMIN_PASSWORD to KC_BOOTSTRAP_ADMIN_PASSWORD.

TODOS and Open Questions

* [x] Check logging

Learning

The official keycloak 26.0.0 release notes https://www.keycloak.org/docs/latest/upgrading/index.html#admin-bootstrapping-and-recovery say:

> the environment variables KEYCLOAK_ADMIN and KEYCLOAK_ADMIN_PASSWORD have been deprecated. You should use KC_BOOTSTRAP_ADMIN_USERNAME and KC_BOOTSTRAP_ADMIN_PASSWORD instead.