### PR TITLE
Fix GetSidecarImage return value for default sidecar image

### DIFF
--- a/eureka-cli/internal/module.go
+++ b/eureka-cli/internal/module.go
@@ -151,7 +151,7 @@ func GetSidecarImage(commandName string, registryModules []*RegistryModule) (str
 		return fmt.Sprintf("%s:%s", localImage.(string), sidecarImageVersion), false
 	}
 
-	return fmt.Sprintf("%s/%s", GetImageRegistryNamespace(commandName, sidecarImageVersion), fmt.Sprintf("%s:%s", sidecarModule[SidecarModuleImageEntryKey].(string), sidecarImageVersion)), false
+	return fmt.Sprintf("%s/%s", GetImageRegistryNamespace(commandName, sidecarImageVersion), fmt.Sprintf("%s:%s", sidecarModule[SidecarModuleImageEntryKey].(string), sidecarImageVersion)), true
 }
 
 func getSidecarImageVersion(commandName string, registryModules []*RegistryModule, sidecarConfigVersion any) string {


### PR DESCRIPTION
For the default sidecar image GetSidecarImage returns false for pullSidecarImage which causes the deployement to fail. This pull request fixes the return value.