### PR TITLE
Increase memory limit for elasticsearch

### DIFF
--- a/eureka-cli/misc/docker-compose.yaml
+++ b/eureka-cli/misc/docker-compose.yaml
@@ -295,7 +295,7 @@ services:
     image: bitnami/elasticsearch:8.18.0
     restart: unless-stopped
     cpus: 1
-    mem_limit: 1g
+    mem_limit: 2g
     environment:
       ELASTICSEARCH_PLUGINS:
         "analysis-icu,analysis-kuromoji,analysis-smartcn,analysis-nori,analysis-phonetic"


### PR DESCRIPTION
With mem_limit: 1g the elasticsearch container fails to initialize because it runs out of memory. With mem_limit: 2g the container is successfully deployed with about 78% memory usage.