### PR TITLE
Improve port allocation

### DIFF
--- a/eureka-cli/README.md
+++ b/eureka-cli/README.md
@@ -219,7 +219,7 @@ eureka-cli getKeycloakAccessToken -t diku
 - Get an Edge API key for a user and tenant
 
 ```bash
-eureka-cli getEdgeApiKey -t diku -U diku_admin -c config.edge.yaml
+eureka-cli -c config.edge.yaml getEdgeApiKey -t diku -U diku_admin 
 ```
 
 - Check if module internal ports are accessible

--- a/eureka-cli/cmd/attachCapabilitySets.go
+++ b/eureka-cli/cmd/attachCapabilitySets.go
@@ -93,8 +93,8 @@ func getConsumerGroupLag(tenant string, consumerGroup string, initialLag int) (l
 			internal.LogWarn(attachCapabilitySetsCommand, withEnableDebug, fmt.Sprintf("internal.RunCommandReturnOutput warning - %s", stderr.String()))
 			return initialLag
 		}
-
 		internal.LogErrorPrintStderrPanic(attachCapabilitySetsCommand, "internal.RunCommandReturnOutput error", stderr.String())
+
 		return 0
 	}
 

--- a/eureka-cli/cmd/deployManagement.go
+++ b/eureka-cli/cmd/deployManagement.go
@@ -38,6 +38,9 @@ var deployManagementCmd = &cobra.Command{
 }
 
 func DeployManagement() {
+	internal.PortStartIndex = viper.GetInt(internal.ApplicationPortStartKey)
+	internal.PortEndIndex = viper.GetInt(internal.ApplicationPortEndKey)
+	internal.ReservedPorts = []int{}
 	environment := internal.GetEnvironmentFromConfig(deployManagementCommand, internal.EnvironmentKey)
 
 	slog.Info(deployManagementCommand, internal.GetFuncName(), "### READING BACKEND MODULES FROM CONFIG ###")

--- a/eureka-cli/cmd/deployModules.go
+++ b/eureka-cli/cmd/deployModules.go
@@ -42,6 +42,7 @@ func DeployModules() {
 	registryUrl := viper.GetString(internal.RegistryUrlKey)
 	internal.PortStartIndex = viper.GetInt(internal.ApplicationPortStartKey)
 	internal.PortEndIndex = viper.GetInt(internal.ApplicationPortEndKey)
+	internal.ReservedPorts = []int{}
 	environment := internal.GetEnvironmentFromConfig(deployModulesCommand, internal.EnvironmentKey)
 	sidecarEnvironment := internal.GetEnvironmentFromConfig(deployModulesCommand, internal.SidecarModuleEnvironmentKey)
 

--- a/eureka-cli/cmd/interceptModule.go
+++ b/eureka-cli/cmd/interceptModule.go
@@ -143,10 +143,10 @@ func prepareContainerNetwork(dto *InterceptModuleDto, moduleAndSidecar bool) {
 	dto.networkConfig = internal.NewModuleNetworkConfig()
 
 	if moduleAndSidecar {
-		moduleServerPort := internal.GetFreePortFromRange(interceptModuleCommand, dto.portStart, dto.portEnd, []int{})
-		moduleDebugPort := internal.GetFreePortFromRange(interceptModuleCommand, dto.portStart, dto.portEnd, []int{moduleServerPort})
-		sidecarServerPort := internal.GetFreePortFromRange(interceptModuleCommand, dto.portStart, dto.portEnd, []int{moduleServerPort, moduleDebugPort})
-		sidecarDebugPort := internal.GetFreePortFromRange(interceptModuleCommand, dto.portStart, dto.portEnd, []int{moduleServerPort, moduleDebugPort, sidecarServerPort})
+		moduleServerPort := internal.GetAndSetFreePortFromRange(interceptModuleCommand, dto.portStart, dto.portEnd, &internal.ReservedPorts)
+		moduleDebugPort := internal.GetAndSetFreePortFromRange(interceptModuleCommand, dto.portStart, dto.portEnd, &internal.ReservedPorts)
+		sidecarServerPort := internal.GetAndSetFreePortFromRange(interceptModuleCommand, dto.portStart, dto.portEnd, &internal.ReservedPorts)
+		sidecarDebugPort := internal.GetAndSetFreePortFromRange(interceptModuleCommand, dto.portStart, dto.portEnd, &internal.ReservedPorts)
 
 		dto.backendModule, dto.registryModule = internal.GetBackendModule(interceptModuleCommand, dto.deployModulesDto, dto.moduleName)
 		dto.backendModule.ModulePortBindings = internal.CreatePortBindings(moduleServerPort, moduleDebugPort, dto.backendModule.ModuleServerPort)
@@ -156,7 +156,7 @@ func prepareContainerNetwork(dto *InterceptModuleDto, moduleAndSidecar bool) {
 	}
 
 	sidecarServerPort := internal.ExtractPortFromUrl(interceptModuleCommand, *dto.sidecarUrl)
-	sidecarDebugPort := internal.GetFreePortFromRange(interceptModuleCommand, dto.portStart, dto.portEnd, []int{sidecarServerPort})
+	sidecarDebugPort := internal.GetAndSetFreePortFromRange(interceptModuleCommand, dto.portStart, dto.portEnd, &internal.ReservedPorts)
 
 	dto.sidecarServerPort = sidecarServerPort
 
@@ -177,19 +177,25 @@ func deploySidecar(printModuleEnvironment bool, dto *InterceptModuleDto, client 
 	sidecarResources := internal.CreateResources(false, viper.GetStringMap(internal.SidecarModuleResourcesKey))
 	sidecarEnvironment := internal.GetSidecarEnvironment(dto.deployModulesDto, dto.registryModule, *dto.backendModule, dto.moduleUrl, dto.sidecarUrl)
 	sidecarDeployDto := internal.NewDeploySidecarDto(dto.registryModule.SidecarName, sidecarImage, sidecarEnvironment, *dto.backendModule, dto.networkConfig, sidecarResources)
+
 	sidecarDeployDto.PullImage = pullSidecarImage
+
 	internal.DeployModule(interceptModuleCommand, client, sidecarDeployDto)
 
 	if printModuleEnvironment {
-		moduleOkapiEnvironment := []string{"OKAPI_HOST=localhost",
-			fmt.Sprintf("OKAPI_PORT=%d", dto.sidecarServerPort),
-			"OKAPI_SERVICE_HOST=localhost",
-			fmt.Sprintf("OKAPI_SERVICE_PORT=%d", dto.sidecarServerPort),
-			fmt.Sprintf("OKAPI_SERVICE_URL=http://localhost:%d", dto.sidecarServerPort),
-			fmt.Sprintf("OKAPI_URL=http://localhost:%d", dto.sidecarServerPort),
-		}
 		moduleEnvironment := internal.GetModuleEnvironment(dto.deployModulesDto, dto.registryModule, *dto.backendModule)
-		moduleEnvironment = append(moduleEnvironment, moduleOkapiEnvironment...)
+
+		if dto.backendModule.UseOkapiUrl {
+			moduleOkapiEnvironment := []string{"OKAPI_HOST=localhost",
+				fmt.Sprintf("OKAPI_PORT=%d", dto.sidecarServerPort),
+				"OKAPI_SERVICE_HOST=localhost",
+				fmt.Sprintf("OKAPI_SERVICE_PORT=%d", dto.sidecarServerPort),
+				fmt.Sprintf("OKAPI_SERVICE_URL=http://localhost:%d", dto.sidecarServerPort),
+				fmt.Sprintf("OKAPI_URL=http://localhost:%d", dto.sidecarServerPort),
+			}
+
+			moduleEnvironment = append(moduleEnvironment, moduleOkapiEnvironment...)
+		}
 
 		fmt.Println()
 		fmt.Printf("### %s ###\n", "Can be embedded into IntelliJ Run/Debug Configuration")

--- a/eureka-cli/config.edge.yaml
+++ b/eureka-cli/config.edge.yaml
@@ -5,8 +5,8 @@ application:
   version: 1.0.0
   platform: base
   fetch-descriptors: false
-  port-start: 34000
-  port-end: 34999
+  port-start: 33000
+  port-end: 33999
   dependencies:
     name: app-combined
     version: 1.0.0

--- a/eureka-cli/config.search.yaml
+++ b/eureka-cli/config.search.yaml
@@ -5,8 +5,8 @@ application:
   version: 1.0.0
   platform: base
   fetch-descriptors: false
-  port-start: 33000
-  port-end: 33999
+  port-start: 32000
+  port-end: 32999
   dependencies:
     name: app-combined
     version: 1.0.0

--- a/eureka-cli/internal/config.go
+++ b/eureka-cli/internal/config.go
@@ -57,8 +57,9 @@ const (
 )
 
 var (
-	PortStartIndex int = 30000
-	PortEndIndex   int = 30999
+	PortStartIndex int   = 30000
+	PortEndIndex   int   = 30999
+	ReservedPorts  []int = []int{}
 )
 
 func GetGatewayUrlTemplate(commandName string) string {
@@ -96,47 +97,69 @@ func GetBackendModulesFromConfig(commandName string, managementOnly bool, printO
 	backendModulesMap := make(map[string]BackendModule)
 
 	for name, value := range backendModulesAnyMap {
-		var dto BackendModuleDto
-		if value == nil {
-			dto = createDefaultBackendDto(commandName, name)
-		} else {
-			dto = createConfigurableBackendDto(commandName, value, name)
+		if managementOnly && !IsManagementModule(name) || !managementOnly && IsManagementModule(name) {
+			continue
 		}
 
-		if dto.deploySidecar != nil && *dto.deploySidecar {
-			backendModulesMap[name] = *NewBackendModuleWithSidecar(dto)
-		} else {
-			backendModulesMap[name] = *NewBackendModule(dto)
-		}
+		backendDto := createBackendDto(commandName, name, value)
+		backendModulesMap[name] = *createBackendModule(commandName, backendDto)
 
-		moduleInfo := name
-		if dto.version != nil {
-			moduleInfo = fmt.Sprintf("%s with fixed version %s", name, *dto.version)
-		}
-
-		if printOutput {
-			slog.Info(commandName, GetFuncName(), fmt.Sprintf("Found backend module in config: %s", moduleInfo))
-		}
+		printModuleInfo(commandName, name, backendDto, backendModulesMap, printOutput)
 	}
 
 	return backendModulesMap
 }
 
-func createDefaultBackendDto(commandName string, name string) (dto BackendModuleDto) {
-	dto.deployModule = true
-
-	if !strings.HasPrefix(name, ManagementModulePattern) && !strings.HasPrefix(name, EdgeModulePattern) {
-		dto.deploySidecar = getDefaultDeploySidecar()
+func createBackendDto(commandName string, name string, value any) BackendModuleDto {
+	if value == nil {
+		return createDefaultBackendDto(commandName, name)
 	}
 
-	if PortStartIndex+1 >= PortEndIndex {
-		LogErrorPanic(commandName, "internal.createDefaultBackendDto error - incremented PortStartIndex is exceeding PortEndIndex limit")
+	return createConfigurableBackendDto(commandName, value, name)
+}
+
+func createBackendModule(commandName string, dto BackendModuleDto) *BackendModule {
+	if dto.deploySidecar != nil && *dto.deploySidecar {
+		return NewBackendModuleWithSidecar(commandName, dto)
+	}
+
+	return NewBackendModule(commandName, dto)
+}
+
+func printModuleInfo(commandName string, name string, dto BackendModuleDto, backendModulesMap map[string]BackendModule, printOutput bool) {
+	if !printOutput {
 		return
 	}
 
-	dto.port = &PortStartIndex
-	PortStartIndex++
+	moduleInfo := name
+	if dto.version != nil {
+		moduleInfo = fmt.Sprintf("%s with fixed version %s", name, *dto.version)
+	}
 
+	moduleServerPort := backendModulesMap[name].ModuleExposedServerPort
+	moduleDebugPort := backendModulesMap[name].ModuleExposedDebugPort
+	sidecarServerPort := backendModulesMap[name].SidecarExposedServerPort
+	sidecarDebugPort := backendModulesMap[name].SidecarExposedDebugPort
+
+	slog.Info(commandName, GetFuncName(), fmt.Sprintf("Found backend module in config: %s, reserved ports: [%d|%d|%d|%d]", moduleInfo, moduleServerPort, moduleDebugPort, sidecarServerPort, sidecarDebugPort))
+}
+
+func IsManagementModule(name string) bool {
+	return strings.HasPrefix(name, ManagementModulePattern)
+}
+
+func IsEdgeModule(name string) bool {
+	return strings.HasPrefix(name, EdgeModulePattern)
+}
+
+func createDefaultBackendDto(commandName string, name string) (dto BackendModuleDto) {
+	dto.deployModule = true
+
+	if !IsManagementModule(name) && !IsEdgeModule(name) {
+		dto.deploySidecar = getDefaultDeploySidecar()
+	}
+
+	dto.port = getDefaultPort(commandName)
 	dto.portServer = getDefaultPortServer()
 	dto.environment = make(map[string]any)
 	dto.resources = make(map[string]any)
@@ -158,7 +181,7 @@ func createConfigurableBackendDto(commandName string, value any, name string) (d
 	dto.disableSystemUser = getKeyOrDefault(mapEntry, ModuleDisableSystemUserEntryKey, false).(bool)
 	dto.useOkapiUrl = getKeyOrDefault(mapEntry, ModuleUseOkapiUrlEntryKey, false).(bool)
 	dto.version = getVersion(mapEntry)
-	dto.port = getPort(mapEntry)
+	dto.port = getPort(commandName, mapEntry)
 	dto.portServer = getPortServer(mapEntry)
 	dto.environment = getKeyOrDefault(mapEntry, ModuleEnvironmentEntryKey, make(map[string]any)).(map[string]any)
 	dto.resources = getKeyOrDefault(mapEntry, ModuleResourceEntryKey, make(map[string]any)).(map[string]any)
@@ -206,15 +229,19 @@ func getVersion(mapEntry map[string]any) *string {
 	return &versionValue
 }
 
-func getPort(mapEntry map[string]any) *int {
+func getPort(commandName string, mapEntry map[string]any) *int {
 	if mapEntry[ModulePortEntryKey] == nil {
-		PortStartIndex++
-
-		return &PortStartIndex
+		return getDefaultPort(commandName)
 	}
 	portValue := mapEntry[ModulePortEntryKey].(int)
 
 	return &portValue
+}
+
+func getDefaultPort(commandName string) *int {
+	freePort := GetAndSetFreePortFromRange(commandName, PortStartIndex, PortEndIndex, &ReservedPorts)
+
+	return &freePort
 }
 
 func getPortServer(mapEntry map[string]any) *int {

--- a/eureka-cli/internal/module.go
+++ b/eureka-cli/internal/module.go
@@ -100,6 +100,7 @@ func DeployModules(commandName string, client *client.Client, dto *DeployModules
 				go func() {
 					sidecarEnvironment := GetSidecarEnvironment(dto, registryModule, backendModule, nil, nil)
 					sidecarDeployDto := NewDeploySidecarDto(registryModule.SidecarName, sidecarImage, sidecarEnvironment, backendModule, networkConfig, sidecarResources)
+
 					DeployModule(commandName, client, sidecarDeployDto)
 				}()
 			}
@@ -148,7 +149,9 @@ func GetSidecarImage(commandName string, registryModules []*RegistryModule) (str
 		return fmt.Sprintf("%s:%s", localImage.(string), sidecarImageVersion), false
 	}
 
-	return fmt.Sprintf("%s/%s", GetImageRegistryNamespace(commandName, sidecarImageVersion), fmt.Sprintf("%s:%s", sidecarModule[SidecarModuleImageEntryKey].(string), sidecarImageVersion)), true
+	namespace := GetImageRegistryNamespace(commandName, sidecarImageVersion)
+	image := sidecarModule[SidecarModuleImageEntryKey]
+	return fmt.Sprintf("%s/%s", namespace, fmt.Sprintf("%s:%s", image.(string), sidecarImageVersion)), true
 }
 
 func getSidecarImageVersion(commandName string, registryModules []*RegistryModule, sidecarConfigVersion any) string {
@@ -311,6 +314,6 @@ func undeployModule(commandName string, client *client.Client, deployedModule ty
 		removeContainerFunc()
 	}
 
-	slog.Info(commandName, GetFuncName(), fmt.Sprintf("Undeployed module container %s %s %s", deployedModule.ID,
-		strings.ReplaceAll(deployedModule.Names[0], "/", ""), deployedModule.Status))
+	containerName := strings.ReplaceAll(deployedModule.Names[0], "/", "")
+	slog.Info(commandName, GetFuncName(), fmt.Sprintf("Undeployed module container %s %s %s", deployedModule.ID, containerName, deployedModule.Status))
 }

--- a/eureka-cli/internal/util.go
+++ b/eureka-cli/internal/util.go
@@ -246,13 +246,16 @@ func GetFuncName() string {
 
 // ######## Net ########
 
-func GetFreePortFromRange(commandName string, portStart, portEnd int, excludeReservedPorts []int) int {
-	for port := portStart + 1; port <= portEnd; port++ {
-		if !slices.Contains(excludeReservedPorts, port) && IsPortFree(commandName, portStart, portEnd, port) {
+func GetAndSetFreePortFromRange(commandName string, portStart, portEnd int, excludeReservedPorts *[]int) int {
+	for port := portStart; port <= portEnd; port++ {
+		if !slices.Contains(*excludeReservedPorts, port) && IsPortFree(commandName, portStart, portEnd, port) {
+			*excludeReservedPorts = append(*excludeReservedPorts, port)
+
 			return port
 		}
 	}
 	LogErrorPanic(commandName, fmt.Sprintf("getFreePortFromRange() error - Cannot find free TCP ports in range %d-%d", portStart, portEnd))
+
 	return 0
 }
 

--- a/eureka-cli/misc/docker-compose.yaml
+++ b/eureka-cli/misc/docker-compose.yaml
@@ -115,7 +115,7 @@ services:
     container_name: kafka
     image: bitnami/kafka:3.9.0
     restart: unless-stopped
-    cpus: 2
+    cpus: 4
     mem_limit: 2g
     depends_on:
       zookeeper:


### PR DESCRIPTION
## Purpose

- Improve port allocation be defining ports

## Approach

-  Improve port allocation by setting a port only after a TCP check to avoid potential port conflicts if using Kubernetes NodePort or LoadBalancer with MetalLB Services locally (i.e. because these typically use the same port range - 30000-32767)
- Apply other minor changes to attachCapabilitySets command, and to misc/docker-compose.yaml for stability