### PR TITLE
Update env vars

### DIFF
--- a/eureka-cli/.gitignore
+++ b/eureka-cli/.gitignore
@@ -3,9 +3,7 @@ log
 tmp
 temp
 
-INSTALL.md
-UPGRADE.md
-RELEASE.md
+SETUP.md
 
 temp*.go
 config.temp-*.yaml

--- a/eureka-cli/README.md
+++ b/eureka-cli/README.md
@@ -57,7 +57,7 @@ echo "source <(eureka-cli completion bash)" >> ~/.bash_profile
 source ~/.bash_profile
 ```
 
-> Type the command partially and hit TAB to see the available command suggestions or full command autocomplete
+> Type `eureka-cli` and hit TAB to see the available suggestions or full autocompletion
 
 ### Deploy the combined application
 

--- a/eureka-cli/config.combined.yaml
+++ b/eureka-cli/config.combined.yaml
@@ -141,7 +141,8 @@ backend-modules:
       MODULE_URL: http://mgr-tenant-entitlements.eureka:8081
       MT_CLIENT_URL: http://mgr-tenants.eureka:8081
       AM_CLIENT_URL: http://mgr-applications.eureka:8081
-      VALIDATION_INTERFACE_INTEGRITY_ENABLED: "false"
+      VALIDATION_INTERFACE_INTEGRITY_ENTITLEMENT_ENABLED: "false"
+      VALIDATION_INTERFACE_INTEGRITY_UPGRADE_ENABLED: "false"
       ROUTEMANAGEMENT_ENABLE: "false"
       FOLIO_CLIENT_CONNECT_TIMEOUT: 600s
       FOLIO_CLIENT_READ_TIMEOUT: 600s

--- a/eureka-cli/config.ecs.yaml
+++ b/eureka-cli/config.ecs.yaml
@@ -206,7 +206,8 @@ backend-modules:
       MODULE_URL: http://mgr-tenant-entitlements.eureka:8081
       MT_CLIENT_URL: http://mgr-tenants.eureka:8081
       AM_CLIENT_URL: http://mgr-applications.eureka:8081
-      VALIDATION_INTERFACE_INTEGRITY_ENABLED: "false"
+      VALIDATION_INTERFACE_INTEGRITY_ENTITLEMENT_ENABLED: "false"
+      VALIDATION_INTERFACE_INTEGRITY_UPGRADE_ENABLED: "false"
       ROUTEMANAGEMENT_ENABLE: "false"
       FOLIO_CLIENT_CONNECT_TIMEOUT: 600s
       FOLIO_CLIENT_READ_TIMEOUT: 600s

--- a/eureka-cli/config.import.yaml
+++ b/eureka-cli/config.import.yaml
@@ -154,7 +154,8 @@ backend-modules:
       MODULE_URL: http://mgr-tenant-entitlements.eureka:8081
       MT_CLIENT_URL: http://mgr-tenants.eureka:8081
       AM_CLIENT_URL: http://mgr-applications.eureka:8081
-      VALIDATION_INTERFACE_INTEGRITY_ENABLED: "false"
+      VALIDATION_INTERFACE_INTEGRITY_ENTITLEMENT_ENABLED: "false"
+      VALIDATION_INTERFACE_INTEGRITY_UPGRADE_ENABLED: "false"
       ROUTEMANAGEMENT_ENABLE: "false"
       FOLIO_CLIENT_CONNECT_TIMEOUT: 600s
       FOLIO_CLIENT_READ_TIMEOUT: 600s


### PR DESCRIPTION
## Purpose

- Update mgr-tenant-entitlements module based on the env vars
  - <https://github.com/folio-org/mgr-tenant-entitlements/pull/219>
  - <https://github.com/folio-org/mgr-tenant-entitlements/pull/221>

## Approach

- Change `VALIDATION_INTERFACE_INTEGRITY_ENABLED` to `VALIDATION_INTERFACE_INTEGRITY_ENTITLEMENT_ENABLED`
- Add `VALIDATION_INTERFACE_INTEGRITY_UPGRADE_ENABLED` to account for the upgrade functionality

