### PR TITLE
[ECLI-16]. Add a standalone single-ECS profile

### DIFF
--- a/eureka-cli/README.md
+++ b/eureka-cli/README.md
@@ -59,27 +59,27 @@ source ~/.bash_profile
 
 > Type `eureka-cli` and hit TAB to see the available suggestions or full autocompletion
 
-### Deploy the combined application
+### Deploy the _combined_ application
 
 By default, public images from DockerHub (folioci & folioorg namespaces) will be used.
 
 Available flags:
 
-| Short | Long                | Description                                                  |
-|-------|---------------------|--------------------------------------------------------------|
-| `-p`  | `--profile`         | Select profile (combined, export, search, edge, ecs, import) |
-| `-c`  | `--configFile`      | Specify config file path                                     |
-| `-o`  | `--overwriteFiles`  | Overwrite files in .eureka home directory                    |
-| `-d`  | `--enableDebug`     | Enable debug mode                                            |
-| `-R`  | `--onlyRequired`    | Use only required system containers                          |
-| `-b`  | `--buildImages`     | Build Docker images                                          |
-| `-u`  | `--updateCloned`    | Update Git cloned projects                                   |
+| Short | Long                | Description                                                             |
+|-------|---------------------|------------------------------------------------------------------------ |
+| `-p`  | `--profile`         | Select profile (combined, export, search, edge, ecs, ecs-single import) |
+| `-c`  | `--configFile`      | Specify config file path                                                |
+| `-o`  | `--overwriteFiles`  | Overwrite files in .eureka home directory                               |
+| `-d`  | `--enableDebug`     | Enable debug mode                                                       |
+| `-R`  | `--onlyRequired`    | Use only required system containers                                     |
+| `-b`  | `--buildImages`     | Build Docker images                                                     |
+| `-u`  | `--updateCloned`    | Update Git cloned projects                                              |
 
 ```bash
 eureka-cli -c ./config.combined.yaml deployApplication
 ```
 
-> If no profile or config file is passed, the combined profile will be inferred and used
+> If no profile or config file is passed, the _combined_ profile will be inferred and used
 
 - Use the debug `-d` flag to troubleshoot your environment deployment to see how the CLI interacts with **Kong** via HTTP
 
@@ -99,7 +99,7 @@ eureka-cli deployApplication -R
 eureka-cli -p combined deployApplication
 ```
 
-> Available profiles are: _combined_, _export_, _search_, _edge_, _ecs_ and _import_ (_combined_, _ecs_ and _import_ are standalone applications)
+> Available profiles are: _combined_, _export_, _search_, _edge_, _ecs_, _ecs-single_ and _import_ (_combined_, _ecs_, _ecs-single_ and _import_ are standalone applications)
 
 - It can be combined with the `-o` flag to overwrite all existing files in the `.eureka` home directory to receive changes from upstream
 
@@ -129,13 +129,13 @@ eureka-cli buildSystem
 eureka-cli buildSystem -u
 ```
 
-### Undeploy the combined application
+### Undeploy the _combined_ application
 
 ```bash
 eureka-cli undeployApplication
 ```
 
-### Deploy the combined application from AWS ECR
+### Deploy the _combined_ application from AWS ECR
 
 To use AWS ECR as your container registry instead of the public Folio DockerHub, set `AWS_ECR_FOLIO_REPO` in your environment. When this environment variable is defined, it is assumed that this repository is private and you have also defined credentials in your environment. The value of this variable should be the URL of your repository.
 
@@ -157,18 +157,32 @@ AWS_SDK_LOAD_CONFIG=true eureka-cli deployApplication
 
 > See docs/AWS_CLI.md to prepare AWS CLI beforehand
 
-### Deploy the ecs application
+### Deploy the _ecs_ application
 
-The ecs application is a standalone application that deploys a UI container for each consortium. By default, it creates 3 tenants for the first consortium (ecs) and 2 tenants for the second one (ecs2). This profile also deploys _mod-okapi-facade_ and _mod-search_ modules along with the _elasticsearch_ system container.
+The _ecs_ application is a standalone application that deploys a UI container for each consortium. By default, it creates 3 tenants for the first consortium (ecs) and 2 tenants for the second one (ecs2). This profile also deploys _mod-okapi-facade_ and _mod-search_ modules along with the _elasticsearch_ system container.
 
 ```bash
 eureka-cli -p ecs deployApplication -oR
 ```
 
-### Undeploy the ecs application
+### Undeploy the _ecs_ application
 
 ```bash
 eureka-cli -p ecs undeployApplication
+```
+
+### Deploy the _ecs-single_ application
+
+We can use the _ecs-single_ profile to deploy an environment with just a single consortium. This profile will provision only 3 tenants (i.e. ecs, university and college) with just a single UI container. This profile is preferred over the _ecs_ when there is an obvious resource constraint on the host machine because of how many Kafka topics there needs to be maintained during and after tenant entitlement.
+
+```bash
+eureka-cli -p ecs-single deployApplication -oR
+```
+
+### Undeploy the _ecs-single_ application
+
+```bash
+eureka-cli -p ecs-single undeployApplication
 ```
 
 ### Deploy the import application
@@ -307,7 +321,7 @@ eureka-cli getEdgeApiKey -t diku -U diku_admin
 eureka-cli -p {{profile}} reindexElasticsearch
 ```
 
-> This command assumes that _mod-search_ module and _elasticsearch_ system container are deployed or if `{{profile}}` is being replaced by either _search_ or _ecs_ profiles
+> This command assumes that _mod-search_ module and _elasticsearch_ system container are deployed or if `{{profile}}` is being replaced by either _search_, _ecs_ or _ecs-single_ profiles
 
 - Check if module internal ports are accessible
 

--- a/eureka-cli/config.combined.yaml
+++ b/eureka-cli/config.combined.yaml
@@ -248,8 +248,8 @@ frontend-modules:
   folio_plugin-find-authority:
 custom-frontend-modules:
   folio_authorization-roles:
-    version: 2.1.109900000000207
+    version: 2.1.109900000000214
   folio_authorization-policies:
-    version: 2.0.10990000000095
+    version: 2.0.109900000000102
   folio_plugin-select-application:
-    version: 2.0.10990000000077
+    version: 2.0.109900000000116

--- a/eureka-cli/config.ecs-single.yaml
+++ b/eureka-cli/config.ecs-single.yaml
@@ -55,9 +55,6 @@ consortiums:
   ecs:
     create-consortium: true
     enable-central-ordering: true
-  ecs2:
-    create-consortium: true
-    enable-central-ordering: true
 tenants:
   ecs:
     consortium: ecs
@@ -68,18 +65,6 @@ tenants:
     platform-complete-url: http://localhost:3000
   university:
     consortium: ecs
-  college:
-    consortium: ecs
-  # Secondary Cluster
-  ecs2:
-    consortium: ecs2
-    deploy-ui: true
-    single-tenant: false
-    enable-ecs-request: false
-    central-tenant: true
-    platform-complete-url: http://localhost:3001
-  university2:
-    consortium: ecs2
 roles:
   ecs_admin_role:
     consortium: ecs 
@@ -88,19 +73,6 @@ roles:
   university_admin_role:
     consortium: ecs
     tenant: university
-    capability-sets: ["all"]
-  college_admin_role:
-    consortium: ecs
-    tenant: college
-    capability-sets: ["all"]
-  # Secondary Cluster
-  ecs_admin_role2:
-    consortium: ecs2
-    tenant: ecs2
-    capability-sets: ["all"]
-  university_admin_role2:
-    consortium: ecs2
-    tenant: university2
     capability-sets: ["all"]
 users:
   ecs_admin:
@@ -117,28 +89,6 @@ users:
     last-name: John
     first-name: Doe
     roles: ["university_admin_role"]
-  college_admin:
-    consortium: ecs
-    tenant: college
-    password: admin
-    last-name: John
-    first-name: Doe
-    roles: ["college_admin_role"]
-  # Secondary Cluster
-  ecs_admin2:
-    consortium: ecs2 
-    tenant: ecs2
-    password: admin
-    last-name: John
-    first-name: Doe
-    roles: ["ecs_admin_role2"]
-  university_admin2:
-    consortium: ecs2 
-    tenant: university2
-    password: admin
-    last-name: John
-    first-name: Doe
-    roles: ["university_admin_role2"]
 sidecar-module:
   image: folio-module-sidecar
   environment:

--- a/eureka-cli/config.import.yaml
+++ b/eureka-cli/config.import.yaml
@@ -281,8 +281,8 @@ frontend-modules:
   folio_plugin-find-authority:
 custom-frontend-modules:
   folio_authorization-roles:
-    version: 2.1.109900000000207
+    version: 2.1.109900000000214
   folio_authorization-policies:
-    version: 2.0.10990000000095
+    version: 2.0.109900000000102
   folio_plugin-select-application:
-    version: 2.0.10990000000077
+    version: 2.0.109900000000116

--- a/eureka-cli/internal/config.go
+++ b/eureka-cli/internal/config.go
@@ -62,7 +62,7 @@ var (
 	PortEndIndex   int   = 30999
 	ReservedPorts  []int = []int{}
 
-	AvailableProfiles = []string{"combined", "export", "search", "edge", "ecs", "import"}
+	AvailableProfiles = []string{"combined", "export", "search", "edge", "ecs", "ecs-single", "import"}
 )
 
 func GetGatewayUrlTemplate(commandName string) string {


### PR DESCRIPTION
## Purpose

- <https://folio-org.atlassian.net/browse/ECLI-16>

## Approach

- Add a standalone config file representing a single ECS profile
- Update shell flag completion
- Update custom UI modules versions
- Update README.md
