### PR TITLE
Add temporarily bitnamilegacy images

### DIFF
--- a/eureka-cli/misc/docker-compose.yaml
+++ b/eureka-cli/misc/docker-compose.yaml
@@ -301,7 +301,7 @@ services:
   ### Elasticsearch (required for mod-search), Kibana (optional) ###
   kibana:
     container_name: kibana
-    image: bitnami/kibana:8.18.0
+    image: bitnamilegacy/kibana:8.18.0-debian-12-r1
     restart: unless-stopped
     cpus: 1
     mem_limit: 1g
@@ -327,7 +327,7 @@ services:
 
   elasticsearch:
     container_name: elasticsearch
-    image: bitnami/elasticsearch:8.18.0
+    image: bitnamilegacy/elasticsearch:8.18.0-debian-12-r2
     restart: unless-stopped
     cpus: 1
     mem_limit: 2g


### PR DESCRIPTION
## Purpose

- Add temporarily `bitnamilegacy` images (a continuation of the previous [PR](https://github.com/folio-org/eureka-setup/pull/78))

## Approach

- Set Kibana image to `bitnamilegacy/kibana:8.18.0-debian-12-r1`
- Set Elasticsearch image to `bitnamilegacy/elasticsearch:8.18.0-debian-12-r2`