### PR TITLE
Add more bitnami legacy images as temporary solution

### DIFF
--- a/eureka-cli/misc/docker-compose.yaml
+++ b/eureka-cli/misc/docker-compose.yaml
@@ -301,7 +301,7 @@ services:
   ### Elasticsearch (required for mod-search), Kibana (optional) ###
   kibana:
     container_name: kibana
-    image: bitnami/kibana:8.18.0
+    image: bitnamilegacy/kibana:8.18.0-debian-12-r1
     restart: unless-stopped
     cpus: 1
     mem_limit: 1g
@@ -327,7 +327,7 @@ services:
 
   elasticsearch:
     container_name: elasticsearch
-    image: bitnami/elasticsearch:8.18.0
+    image: bitnamilegacy/elasticsearch:8.18.0-debian-12-r2
     restart: unless-stopped
     cpus: 1
     mem_limit: 2g


### PR DESCRIPTION
## Purpose

The Bitnami images are no longer freely available, the Bitnami legacy images can be used instead as a temporary solution.

## Approach

Replace the Kibana and Elasticsearch images with the latest legacy images with the same version (the other Bitnami images already have been replaced in PR #78).