### PR TITLE
Remove app platform field

### DIFF
--- a/.github/workflows/build-and-run-cli.yml
+++ b/.github/workflows/build-and-run-cli.yml
@@ -82,6 +82,7 @@ jobs:
           scan-ref: './eureka-cli'
           format: 'sarif'
           output: 'trivy-results.sarif'
+          severity: 'CRITICAL,HIGH'
 
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v4

--- a/.github/workflows/build-and-scan-images.yml
+++ b/.github/workflows/build-and-scan-images.yml
@@ -53,7 +53,6 @@ jobs:
           scan-type: 'image'
           image-ref: '${{ matrix.image.name }}:test'
           format: 'table'
-          severity: 'CRITICAL,HIGH'
           exit-code: '0'
 
       - name: Generate SARIF report
@@ -64,6 +63,7 @@ jobs:
           image-ref: '${{ matrix.image.name }}:test'
           format: 'sarif'
           output: 'trivy-${{ matrix.image.name }}.sarif'
+          severity: 'CRITICAL,HIGH'
 
       - name: Upload scan results to GitHub Security
         uses: github/codeql-action/upload-sarif@v4

--- a/eureka-cli/action/action.go
+++ b/eureka-cli/action/action.go
@@ -38,7 +38,6 @@ type Action struct {
 	ConfigApplicationName             string
 	ConfigApplicationVersion          string
 	ConfigApplicationID               string
-	ConfigApplicationPlatform         string
 	ConfigApplicationFetchDescriptors bool
 	ConfigApplicationPortStart        int
 	ConfigApplicationPortEnd          int
@@ -80,7 +79,6 @@ func New(name string, gatewayURL string, actionParam *Param) *Action {
 		ConfigApplicationName:             applicationName,
 		ConfigApplicationVersion:          applicationVersion,
 		ConfigApplicationID:               fmt.Sprintf("%s-%s", applicationName, applicationVersion),
-		ConfigApplicationPlatform:         viper.GetString(field.ApplicationPlatform),
 		ConfigApplicationFetchDescriptors: viper.GetBool(field.ApplicationFetchDescriptors),
 		ConfigApplicationPortStart:        viper.GetInt(field.ApplicationPortStart),
 		ConfigApplicationPortEnd:          viper.GetInt(field.ApplicationPortEnd),

--- a/eureka-cli/action/action_test.go
+++ b/eureka-cli/action/action_test.go
@@ -56,7 +56,6 @@ func TestNewGeneric_AllViperFields(t *testing.T) {
 			field.RegistryURL:                  "https://registry.test.com",
 			field.InstallFolio:                 "folio-registry-url",
 			field.InstallEureka:                "eureka-registry-url",
-			field.ApplicationPlatform:          "kubernetes",
 			field.ApplicationFetchDescriptors:  true,
 			field.ApplicationPortStart:         8000,
 			field.ApplicationPortEnd:           9000,
@@ -118,7 +117,6 @@ func TestNewGeneric_AllViperFields(t *testing.T) {
 		assert.Equal(t, "https://registry.test.com", result.ConfigRegistryURL)
 		assert.Equal(t, "folio-registry-url", result.ConfigFolioRegistry)
 		assert.Equal(t, "eureka-registry-url", result.ConfigEurekaRegistry)
-		assert.Equal(t, "kubernetes", result.ConfigApplicationPlatform)
 		assert.True(t, result.ConfigApplicationFetchDescriptors)
 		assert.Equal(t, 8000, result.ConfigApplicationPortStart)
 		assert.Equal(t, 9000, result.ConfigApplicationPortEnd)

--- a/eureka-cli/config.combined-native.yaml
+++ b/eureka-cli/config.combined-native.yaml
@@ -255,8 +255,8 @@ frontend-modules:
   folio_plugin-find-authority:
 custom-frontend-modules:
   folio_authorization-roles:
-    version: 2.1.109900000000214
+    version: 2.1.1099000000000223
   folio_authorization-policies:
-    version: 2.0.109900000000102
+    version: 2.0.1099000000000111
   folio_plugin-select-application:
-    version: 2.0.109900000000116
+    version: 2.0.1099000000000124

--- a/eureka-cli/config.combined-native.yaml
+++ b/eureka-cli/config.combined-native.yaml
@@ -3,7 +3,6 @@ profile:
 application:
   name: app-combined
   version: 1.0.0
-  platform: base
   fetch-descriptors: false
   port-start: 30000
   port-end: 30999

--- a/eureka-cli/config.combined.yaml
+++ b/eureka-cli/config.combined.yaml
@@ -3,7 +3,6 @@ profile:
 application:
   name: app-combined
   version: 1.0.0
-  platform: base
   fetch-descriptors: false
   port-start: 30000
   port-end: 30999

--- a/eureka-cli/config.combined.yaml
+++ b/eureka-cli/config.combined.yaml
@@ -251,8 +251,8 @@ frontend-modules:
   folio_plugin-find-authority:
 custom-frontend-modules:
   folio_authorization-roles:
-    version: 2.1.109900000000214
+    version: 2.1.1099000000000223
   folio_authorization-policies:
-    version: 2.0.109900000000102
+    version: 2.0.1099000000000111
   folio_plugin-select-application:
-    version: 2.0.109900000000116
+    version: 2.0.1099000000000124

--- a/eureka-cli/config.ecs-single.yaml
+++ b/eureka-cli/config.ecs-single.yaml
@@ -298,10 +298,10 @@ frontend-modules:
   folio_plugin-find-authority:
 custom-frontend-modules:
   folio_authorization-roles:
-    version: 2.1.109900000000214
+    version: 2.1.1099000000000223
   folio_authorization-policies:
-    version: 2.0.109900000000102
+    version: 2.0.1099000000000111
   folio_plugin-select-application:
-    version: 2.0.109900000000116
+    version: 2.0.1099000000000124
   folio_consortia-settings:
-    version: 3.0.109900000000130
+    version: 3.0.1099000000000154

--- a/eureka-cli/config.ecs-single.yaml
+++ b/eureka-cli/config.ecs-single.yaml
@@ -3,7 +3,6 @@ profile:
 application:
   name: app-ecs
   version: 1.0.0
-  platform: base
   fetch-descriptors: false
   port-start: 30000
   port-end: 30999

--- a/eureka-cli/config.ecs.yaml
+++ b/eureka-cli/config.ecs.yaml
@@ -348,10 +348,10 @@ frontend-modules:
   folio_plugin-find-authority:
 custom-frontend-modules:
   folio_authorization-roles:
-    version: 2.1.109900000000214
+    version: 2.1.1099000000000223
   folio_authorization-policies:
-    version: 2.0.109900000000102
+    version: 2.0.1099000000000111
   folio_plugin-select-application:
-    version: 2.0.109900000000116
+    version: 2.0.1099000000000124
   folio_consortia-settings:
-    version: 3.0.109900000000130
+    version: 3.0.1099000000000154

--- a/eureka-cli/config.ecs.yaml
+++ b/eureka-cli/config.ecs.yaml
@@ -3,7 +3,6 @@ profile:
 application:
   name: app-ecs
   version: 1.0.0
-  platform: base
   fetch-descriptors: false
   port-start: 30000
   port-end: 30999

--- a/eureka-cli/config.edge.yaml
+++ b/eureka-cli/config.edge.yaml
@@ -3,7 +3,6 @@ profile:
 application:
   name: app-edge
   version: 1.0.0
-  platform: base
   fetch-descriptors: false
   port-start: 33000
   port-end: 33999

--- a/eureka-cli/config.export.yaml
+++ b/eureka-cli/config.export.yaml
@@ -3,7 +3,6 @@ profile:
 application:
   name: app-export
   version: 1.0.0
-  platform: base
   fetch-descriptors: false
   port-start: 31000
   port-end: 31999

--- a/eureka-cli/config.import.yaml
+++ b/eureka-cli/config.import.yaml
@@ -3,7 +3,6 @@ profile:
 application:
   name: app-import
   version: 1.0.0
-  platform: base
   fetch-descriptors: false
   port-start: 34000
   port-end: 34999

--- a/eureka-cli/config.import.yaml
+++ b/eureka-cli/config.import.yaml
@@ -284,8 +284,8 @@ frontend-modules:
   folio_plugin-find-authority:
 custom-frontend-modules:
   folio_authorization-roles:
-    version: 2.1.109900000000214
+    version: 2.1.1099000000000223
   folio_authorization-policies:
-    version: 2.0.109900000000102
+    version: 2.0.1099000000000111
   folio_plugin-select-application:
-    version: 2.0.109900000000116
+    version: 2.0.1099000000000124

--- a/eureka-cli/config.search.yaml
+++ b/eureka-cli/config.search.yaml
@@ -3,7 +3,6 @@ profile:
 application:
   name: app-search
   version: 1.0.0
-  platform: base
   fetch-descriptors: false
   port-start: 32000
   port-end: 32999

--- a/eureka-cli/field/field.go
+++ b/eureka-cli/field/field.go
@@ -6,7 +6,6 @@ const (
 	Application                          = "application"
 	ApplicationName                      = "application.name"
 	ApplicationVersion                   = "application.version"
-	ApplicationPlatform                  = "application.platform"
 	ApplicationFetchDescriptors          = "application.fetch-descriptors"
 	ApplicationPortStart                 = "application.port-start"
 	ApplicationPortEnd                   = "application.port-end"

--- a/eureka-cli/managementsvc/management_svc_application.go
+++ b/eureka-cli/managementsvc/management_svc_application.go
@@ -153,7 +153,6 @@ func (ms *ManagementSvc) CreateApplications(extract *models.RegistryExtract) err
 		"name":                ms.Action.ConfigApplicationName,
 		"version":             ms.Action.ConfigApplicationVersion,
 		"description":         "Default",
-		"platform":            ms.Action.ConfigApplicationPlatform,
 		"dependencies":        dependencies,
 		"modules":             backendModules,
 		"uiModules":           frontendModules,

--- a/eureka-cli/managementsvc/management_svc_test.go
+++ b/eureka-cli/managementsvc/management_svc_test.go
@@ -376,7 +376,6 @@ func TestCreateApplications_HeaderCreationError(t *testing.T) {
 	action.ConfigApplicationID = "test-app"
 	action.ConfigApplicationName = "Test Application"
 	action.ConfigApplicationVersion = "1.0.0"
-	action.ConfigApplicationPlatform = "test-platform"
 	mockTenantSvc := &MockTenantSvc{}
 	svc := managementsvc.New(action, mockHTTP, mockTenantSvc)
 
@@ -1408,7 +1407,6 @@ func TestCreateApplications_MinimalSuccess(t *testing.T) {
 	action.ConfigApplicationID = "test-app"
 	action.ConfigApplicationName = "Test Application"
 	action.ConfigApplicationVersion = "1.0.0"
-	action.ConfigApplicationPlatform = "test-platform"
 	mockTenantSvc := &MockTenantSvc{}
 	svc := managementsvc.New(action, mockHTTP, mockTenantSvc)
 
@@ -1494,7 +1492,6 @@ func TestCreateApplications_WithFrontendModule(t *testing.T) {
 	action.ConfigApplicationID = "test-app"
 	action.ConfigApplicationName = "Test Application"
 	action.ConfigApplicationVersion = "1.0.0"
-	action.ConfigApplicationPlatform = "test-platform"
 	mockTenantSvc := &MockTenantSvc{}
 	svc := managementsvc.New(action, mockHTTP, mockTenantSvc)
 
@@ -1560,7 +1557,6 @@ func TestCreateApplications_SkipsManagementModule(t *testing.T) {
 	action.ConfigApplicationID = "test-app"
 	action.ConfigApplicationName = "Test Application"
 	action.ConfigApplicationVersion = "1.0.0"
-	action.ConfigApplicationPlatform = "test-platform"
 	mockTenantSvc := &MockTenantSvc{}
 	svc := managementsvc.New(action, mockHTTP, mockTenantSvc)
 
@@ -1628,7 +1624,6 @@ func TestCreateApplications_HTTPError(t *testing.T) {
 	action.ConfigApplicationID = "test-app"
 	action.ConfigApplicationName = "Test Application"
 	action.ConfigApplicationVersion = "1.0.0"
-	action.ConfigApplicationPlatform = "test-platform"
 	mockTenantSvc := &MockTenantSvc{}
 	svc := managementsvc.New(action, mockHTTP, mockTenantSvc)
 
@@ -1670,7 +1665,6 @@ func TestCreateApplications_WithModuleVersionOverride(t *testing.T) {
 	action.ConfigApplicationID = "test-app"
 	action.ConfigApplicationName = "Test Application"
 	action.ConfigApplicationVersion = "1.0.0"
-	action.ConfigApplicationPlatform = "test-platform"
 	mockTenantSvc := &MockTenantSvc{}
 	svc := managementsvc.New(action, mockHTTP, mockTenantSvc)
 
@@ -1758,7 +1752,6 @@ func TestCreateApplications_WithFetchDescriptorsFromRemote(t *testing.T) {
 	action.ConfigApplicationID = "test-app"
 	action.ConfigApplicationName = "Test Application"
 	action.ConfigApplicationVersion = "1.0.0"
-	action.ConfigApplicationPlatform = "test-platform"
 	action.ConfigApplicationFetchDescriptors = true // Enable descriptor fetching
 	mockTenantSvc := &MockTenantSvc{}
 	svc := managementsvc.New(action, mockHTTP, mockTenantSvc)
@@ -1859,7 +1852,6 @@ func TestCreateApplications_FetchDescriptorError(t *testing.T) {
 	action.ConfigApplicationID = "test-app"
 	action.ConfigApplicationName = "Test Application"
 	action.ConfigApplicationVersion = "1.0.0"
-	action.ConfigApplicationPlatform = "test-platform"
 	action.ConfigApplicationFetchDescriptors = true
 	mockTenantSvc := &MockTenantSvc{}
 	svc := managementsvc.New(action, mockHTTP, mockTenantSvc)
@@ -1915,7 +1907,6 @@ func TestCreateApplications_WithDependencies(t *testing.T) {
 	action.ConfigApplicationID = "test-app"
 	action.ConfigApplicationName = "Test Application"
 	action.ConfigApplicationVersion = "1.0.0"
-	action.ConfigApplicationPlatform = "test-platform"
 	action.ConfigApplicationDependencies = map[string]any{
 		"dependency1": "value1",
 		"dependency2": "value2",
@@ -1972,7 +1963,6 @@ func TestCreateApplications_SkipsModuleNotInConfig(t *testing.T) {
 	action.ConfigApplicationID = "test-app"
 	action.ConfigApplicationName = "Test Application"
 	action.ConfigApplicationVersion = "1.0.0"
-	action.ConfigApplicationPlatform = "test-platform"
 	mockTenantSvc := &MockTenantSvc{}
 	svc := managementsvc.New(action, mockHTTP, mockTenantSvc)
 
@@ -2037,7 +2027,6 @@ func TestCreateApplications_SkipsModuleWithDeployFalse(t *testing.T) {
 	action.ConfigApplicationID = "test-app"
 	action.ConfigApplicationName = "Test Application"
 	action.ConfigApplicationVersion = "1.0.0"
-	action.ConfigApplicationPlatform = "test-platform"
 	mockTenantSvc := &MockTenantSvc{}
 	svc := managementsvc.New(action, mockHTTP, mockTenantSvc)
 
@@ -2105,7 +2094,6 @@ func TestCreateApplications_WithEurekaModules(t *testing.T) {
 	action.ConfigApplicationID = "test-app"
 	action.ConfigApplicationName = "Test Application"
 	action.ConfigApplicationVersion = "1.0.0"
-	action.ConfigApplicationPlatform = "test-platform"
 	mockTenantSvc := &MockTenantSvc{}
 	svc := managementsvc.New(action, mockHTTP, mockTenantSvc)
 
@@ -2186,7 +2174,6 @@ func TestCreateApplications_DiscoveryPostError(t *testing.T) {
 	action.ConfigApplicationID = "test-app"
 	action.ConfigApplicationName = "Test Application"
 	action.ConfigApplicationVersion = "1.0.0"
-	action.ConfigApplicationPlatform = "test-platform"
 	mockTenantSvc := &MockTenantSvc{}
 	svc := managementsvc.New(action, mockHTTP, mockTenantSvc)
 
@@ -2260,7 +2247,6 @@ func TestCreateApplications_WithModuleURLs(t *testing.T) {
 	action.ConfigApplicationID = "test-app"
 	action.ConfigApplicationName = "Test Application"
 	action.ConfigApplicationVersion = "1.0.0"
-	action.ConfigApplicationPlatform = "test-platform"
 	action.ConfigApplicationFetchDescriptors = false // Don't fetch descriptors
 	mockTenantSvc := &MockTenantSvc{}
 	svc := managementsvc.New(action, mockHTTP, mockTenantSvc)
@@ -2348,7 +2334,6 @@ func TestCreateApplications_FrontendModuleWithFetchDescriptors(t *testing.T) {
 	action.ConfigApplicationID = "test-app"
 	action.ConfigApplicationName = "Test Application"
 	action.ConfigApplicationVersion = "1.0.0"
-	action.ConfigApplicationPlatform = "test-platform"
 	action.ConfigApplicationFetchDescriptors = true
 	mockTenantSvc := &MockTenantSvc{}
 	svc := managementsvc.New(action, mockHTTP, mockTenantSvc)
@@ -2433,7 +2418,6 @@ func TestCreateApplications_FrontendModuleWithURL(t *testing.T) {
 	action.ConfigApplicationID = "test-app"
 	action.ConfigApplicationName = "Test Application"
 	action.ConfigApplicationVersion = "1.0.0"
-	action.ConfigApplicationPlatform = "test-platform"
 	action.ConfigApplicationFetchDescriptors = false // Don't fetch
 	mockTenantSvc := &MockTenantSvc{}
 	svc := managementsvc.New(action, mockHTTP, mockTenantSvc)
@@ -2506,7 +2490,6 @@ func TestCreateApplications_FrontendVersionOverride(t *testing.T) {
 	action.ConfigApplicationID = "test-app"
 	action.ConfigApplicationName = "Test Application"
 	action.ConfigApplicationVersion = "1.0.0"
-	action.ConfigApplicationPlatform = "test-platform"
 	mockTenantSvc := &MockTenantSvc{}
 	svc := managementsvc.New(action, mockHTTP, mockTenantSvc)
 
@@ -2579,7 +2562,6 @@ func TestCreateApplications_MixedBackendAndFrontend(t *testing.T) {
 	action.ConfigApplicationID = "test-app"
 	action.ConfigApplicationName = "Test Application"
 	action.ConfigApplicationVersion = "1.0.0"
-	action.ConfigApplicationPlatform = "test-platform"
 	mockTenantSvc := &MockTenantSvc{}
 	svc := managementsvc.New(action, mockHTTP, mockTenantSvc)
 
@@ -2679,7 +2661,6 @@ func TestCreateApplications_BothModulesBackendVersionOverride(t *testing.T) {
 	action.ConfigApplicationID = "test-app"
 	action.ConfigApplicationName = "Test Application"
 	action.ConfigApplicationVersion = "1.0.0"
-	action.ConfigApplicationPlatform = "test-platform"
 	mockTenantSvc := &MockTenantSvc{}
 	svc := managementsvc.New(action, mockHTTP, mockTenantSvc)
 
@@ -2775,7 +2756,6 @@ func TestCreateApplications_BothModulesFrontendVersionOverride(t *testing.T) {
 	action.ConfigApplicationID = "test-app"
 	action.ConfigApplicationName = "Test Application"
 	action.ConfigApplicationVersion = "1.0.0"
-	action.ConfigApplicationPlatform = "test-platform"
 	mockTenantSvc := &MockTenantSvc{}
 	svc := managementsvc.New(action, mockHTTP, mockTenantSvc)
 
@@ -2872,7 +2852,6 @@ func TestCreateApplications_BothModulesBothVersionOverrides(t *testing.T) {
 	action.ConfigApplicationID = "test-app"
 	action.ConfigApplicationName = "Test Application"
 	action.ConfigApplicationVersion = "1.0.0"
-	action.ConfigApplicationPlatform = "test-platform"
 	mockTenantSvc := &MockTenantSvc{}
 	svc := managementsvc.New(action, mockHTTP, mockTenantSvc)
 


### PR DESCRIPTION
## Purpose

- Remove app platform field

## Approach

- Remove `platform` field from all config files as it is no longer needed and will not be supported anymore
- Update GH Trivy scanning workflow to log all findings but report only High and Critical vulnerabilities
- Update tests