### PR TITLE
[ECLI-23]. Add persistence of module versions

### DIFF
--- a/eureka-cli/AGENTS.md
+++ b/eureka-cli/AGENTS.md
@@ -26,6 +26,19 @@ Module versions come from **LSP + FAR**, not install JSON files.
 - **LSP JSON schema**: `{ "eureka-components": [{name, version}], "applications": { "required": [{name, version}], "optional": [{name, version}] } }`
 - `registry.url` is still used by `listModuleVersions` and `GetModuleURL` — do not remove it.
 
+## Module list persistence
+
+The flattened module list is persisted as `~/modules.json` (`constant.ModulesFile`).
+
+| Caller            | Call                         | Behaviour                                          |
+| ----------------- | ---------------------------- | -------------------------------------------------- |
+| `deployModules`   | `GetModules(true, true)`     | Always fetches from LSP+FAR, overwrites file       |
+| `deployManagement`| `GetModules(true, true)`     | Always fetches from LSP+FAR, overwrites file       |
+| `interceptModule` | `GetModules(false, false)`   | Uses file if present; fetches+creates if missing   |
+| `upgradeModule`   | `GetModules(false, false)`   | Uses file if present; fetches+creates if missing   |
+
+`--skipRegistry` flag forces read from file only — hard error if absent. Available on `deployModules`, `deployManagement`, `interceptModule`, `upgradeModule`.
+
 ## isEurekaModule predicate
 
 ```go
@@ -82,14 +95,17 @@ Pre-allocated slice with per-goroutine index — no mutex needed.
 - Set `act.ConfigLspURL` and `act.ConfigFarURL` directly before passing to `registrysvc.New()`
 - `stubLSP` / `stubFAR` helpers in `registrysvc/registry_svc_test.go` for LSP/FAR stubs
 - FAR module slices must be `[]any{map[string]any{...}, ...}` — not `[]map[string]any` — because `GetAnySlice` does `rawValue.([]any)`
-- `MockRegistrySvc` in `cmd/cmd_test.go` and `internal/testhelpers/mocks.go` must implement `RegistryProcessor` interface exactly
+- `MockRegistrySvc` in `cmd/cmd_test.go` and `internal/testhelpers/mocks.go` must implement `RegistryProcessor` interface exactly: `GetModules(verbose bool, forceRefresh bool)`
+- Persistence tests write/read `~/modules.json` directly; use `t.Cleanup(func() { _ = os.Remove(filePath) })` — note the `_ =` to satisfy errcheck
+- Do NOT run `go test ./...` (RAM constrained) — target only affected packages
+- Run `golangci-lint run ./...` once as a finishing move, not after every edit
 
 ## Interface
 
 ```go
 type RegistryProcessor interface {
     GetNamespace(version string) string
-    GetModules(verbose bool) (*models.ProxyModulesByRegistry, error)
+    GetModules(verbose bool, forceRefresh bool) (*models.ProxyModulesByRegistry, error)
     ExtractModuleMetadata(modules *models.ProxyModulesByRegistry)
     GetAuthorizationToken() (string, error)
 }

--- a/eureka-cli/cmd/cmd_additional_test.go
+++ b/eureka-cli/cmd/cmd_additional_test.go
@@ -210,8 +210,8 @@ func TestDeployManagement_Success(t *testing.T) {
 	run.Config.KongSvc = mockKongSvc
 
 	mockModuleProps.On("ReadBackendModules", true, true).Return(map[string]models.BackendModule{}, nil)
-	mockRegistrySvc.On("GetModules", true).Return(&models.ProxyModulesByRegistry{}, nil)
-	mockRegistrySvc.On("ExtractModuleMetadata", mock.Anything).Return()
+	mockRegistrySvc.On("GetModules", true, true).Return(&models.ProxyModulesByRegistry{}, nil)
+	mockRegistrySvc.On("ResolveModuleMetadata", mock.Anything).Return()
 	mockDocker.On("Create").Return(nil, nil)
 	mockModule.On("GetVaultRootToken", mock.Anything).Return("", nil)
 	mockModule.On("DeployModules", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
@@ -240,8 +240,8 @@ func TestDeployManagement_DeployModulesError(t *testing.T) {
 
 	expectedError := assert.AnError
 	mockModuleProps.On("ReadBackendModules", true, true).Return(map[string]models.BackendModule{}, nil)
-	mockRegistrySvc.On("GetModules", true).Return(&models.ProxyModulesByRegistry{}, nil)
-	mockRegistrySvc.On("ExtractModuleMetadata", mock.Anything).Return()
+	mockRegistrySvc.On("GetModules", true, true).Return(&models.ProxyModulesByRegistry{}, nil)
+	mockRegistrySvc.On("ResolveModuleMetadata", mock.Anything).Return()
 	mockDocker.On("Create").Return(nil, nil)
 	mockModule.On("GetVaultRootToken", mock.Anything).Return("", nil)
 	mockModule.On("DeployModules", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, expectedError)
@@ -264,8 +264,8 @@ func TestDeployManagement_NoModulesDeployed(t *testing.T) {
 	run.Config.RegistrySvc = mockRegistrySvc
 
 	mockModuleProps.On("ReadBackendModules", true, true).Return(map[string]models.BackendModule{}, nil)
-	mockRegistrySvc.On("GetModules", true).Return(&models.ProxyModulesByRegistry{}, nil)
-	mockRegistrySvc.On("ExtractModuleMetadata", mock.Anything).Return()
+	mockRegistrySvc.On("GetModules", true, true).Return(&models.ProxyModulesByRegistry{}, nil)
+	mockRegistrySvc.On("ResolveModuleMetadata", mock.Anything).Return()
 	mockDocker.On("Create").Return(nil, nil)
 	mockModule.On("GetVaultRootToken", mock.Anything).Return("", nil)
 	mockModule.On("DeployModules", mock.Anything, mock.Anything, mock.Anything, mock.Anything).

--- a/eureka-cli/cmd/cmd_test.go
+++ b/eureka-cli/cmd/cmd_test.go
@@ -560,15 +560,15 @@ func (m *MockRegistrySvc) GetNamespace(version string) string {
 	return args.String(0)
 }
 
-func (m *MockRegistrySvc) GetModules(verbose bool) (*models.ProxyModulesByRegistry, error) {
-	args := m.Called(verbose)
+func (m *MockRegistrySvc) GetModules(verbose bool, forceRefresh bool) (*models.ProxyModulesByRegistry, error) {
+	args := m.Called(verbose, forceRefresh)
 	if args.Get(0) == nil {
 		return nil, args.Error(1)
 	}
 	return args.Get(0).(*models.ProxyModulesByRegistry), args.Error(1)
 }
 
-func (m *MockRegistrySvc) ExtractModuleMetadata(modules *models.ProxyModulesByRegistry) {
+func (m *MockRegistrySvc) ResolveModuleMetadata(modules *models.ProxyModulesByRegistry) {
 	m.Called(modules)
 }
 
@@ -2273,8 +2273,8 @@ func TestDeployModules_Success(t *testing.T) {
 
 	mockModuleProps.On("ReadBackendModules", false, true).Return(map[string]models.BackendModule{}, nil)
 	mockModuleProps.On("ReadFrontendModules", true).Return(map[string]models.FrontendModule{}, nil)
-	mockRegistrySvc.On("GetModules", true).Return(&models.ProxyModulesByRegistry{}, nil)
-	mockRegistrySvc.On("ExtractModuleMetadata", mock.Anything).Return()
+	mockRegistrySvc.On("GetModules", true, true).Return(&models.ProxyModulesByRegistry{}, nil)
+	mockRegistrySvc.On("ResolveModuleMetadata", mock.Anything).Return()
 	mockDocker.On("Create").Return(nil, nil)
 	mockModule.On("GetVaultRootToken", mock.Anything).Return("", nil)
 	mockModule.On("GetSidecarImage", mock.Anything).Return("test-sidecar:latest", false, nil)
@@ -2357,8 +2357,8 @@ func TestInterceptModule_Success(t *testing.T) {
 		Discovery: []models.ModuleDiscovery{{ID: "module-id-123", Name: "test-module"}},
 	}, nil)
 	mockModuleProps.On("ReadBackendModules", false, false).Return(map[string]models.BackendModule{}, nil)
-	mockRegistrySvc.On("GetModules", false).Return(&models.ProxyModulesByRegistry{}, nil)
-	mockRegistrySvc.On("ExtractModuleMetadata", mock.Anything).Return()
+	mockRegistrySvc.On("GetModules", false, false).Return(&models.ProxyModulesByRegistry{}, nil)
+	mockRegistrySvc.On("ResolveModuleMetadata", mock.Anything).Return()
 	mockDocker.On("Create").Return(nil, nil)
 	mockModule.On("GetVaultRootToken", mock.Anything).Return("", nil)
 	mockInterceptSvc.On("DeployCustomSidecarForInterception", mock.Anything, mock.Anything).Return(nil)
@@ -2389,8 +2389,8 @@ func TestInterceptModule_InterceptError(t *testing.T) {
 		Discovery: []models.ModuleDiscovery{{ID: "module-id-123", Name: "test-module"}},
 	}, nil)
 	mockModuleProps.On("ReadBackendModules", false, false).Return(map[string]models.BackendModule{}, nil)
-	mockRegistrySvc.On("GetModules", false).Return(&models.ProxyModulesByRegistry{}, nil)
-	mockRegistrySvc.On("ExtractModuleMetadata", mock.Anything).Return()
+	mockRegistrySvc.On("GetModules", false, false).Return(&models.ProxyModulesByRegistry{}, nil)
+	mockRegistrySvc.On("ResolveModuleMetadata", mock.Anything).Return()
 	mockDocker.On("Create").Return(nil, nil)
 	mockModule.On("GetVaultRootToken", mock.Anything).Return("", nil)
 	mockInterceptSvc.On("DeployCustomSidecarForInterception", mock.Anything, mock.Anything).Return(expectedError)

--- a/eureka-cli/cmd/deployManagement.go
+++ b/eureka-cli/cmd/deployManagement.go
@@ -49,11 +49,11 @@ func (run *Run) DeployManagement() error {
 	}
 
 	slog.Info(run.Config.Action.Name, "text", "READING BACKEND MODULE REGISTRIES")
-	modules, err := run.Config.RegistrySvc.GetModules(true)
+	modules, err := run.Config.RegistrySvc.GetModules(true, true)
 	if err != nil {
 		return err
 	}
-	run.Config.RegistrySvc.ExtractModuleMetadata(modules)
+	run.Config.RegistrySvc.ResolveModuleMetadata(modules)
 
 	client, err := run.Config.DockerClient.Create()
 	if err != nil {

--- a/eureka-cli/cmd/deployModules.go
+++ b/eureka-cli/cmd/deployModules.go
@@ -56,11 +56,11 @@ func (run *Run) DeployModules() error {
 	}
 
 	slog.Info(run.Config.Action.Name, "text", "READING BACKEND MODULE REGISTRIES")
-	modules, err := run.Config.RegistrySvc.GetModules(true)
+	modules, err := run.Config.RegistrySvc.GetModules(true, true)
 	if err != nil {
 		return err
 	}
-	run.Config.RegistrySvc.ExtractModuleMetadata(modules)
+	run.Config.RegistrySvc.ResolveModuleMetadata(modules)
 
 	client, err := run.Config.DockerClient.Create()
 	if err != nil {

--- a/eureka-cli/cmd/interceptModule.go
+++ b/eureka-cli/cmd/interceptModule.go
@@ -59,11 +59,11 @@ func (run *Run) InterceptModule() error {
 		return err
 	}
 
-	modules, err := run.Config.RegistrySvc.GetModules(false)
+	modules, err := run.Config.RegistrySvc.GetModules(false, false)
 	if err != nil {
 		return err
 	}
-	run.Config.RegistrySvc.ExtractModuleMetadata(modules)
+	run.Config.RegistrySvc.ResolveModuleMetadata(modules)
 
 	client, err := run.Config.DockerClient.Create()
 	if err != nil {

--- a/eureka-cli/cmd/upgradeModule.go
+++ b/eureka-cli/cmd/upgradeModule.go
@@ -183,11 +183,11 @@ func (run *Run) deployNewModuleAndSidecarPair() error {
 		return err
 	}
 
-	modules, err := run.Config.RegistrySvc.GetModules(false)
+	modules, err := run.Config.RegistrySvc.GetModules(false, false)
 	if err != nil {
 		return err
 	}
-	run.Config.RegistrySvc.ExtractModuleMetadata(modules)
+	run.Config.RegistrySvc.ResolveModuleMetadata(modules)
 
 	client, err := run.Config.DockerClient.Create()
 	if err != nil {
@@ -271,6 +271,7 @@ func init() {
 	upgradeModuleCmd.PersistentFlags().BoolVarP(&params.SkipApplication, action.SkipApplication.Long, action.SkipApplication.Short, false, action.SkipApplication.Description)
 	upgradeModuleCmd.PersistentFlags().BoolVarP(&params.SkipModuleDiscovery, action.SkipModuleDiscovery.Long, action.SkipModuleDiscovery.Short, false, action.SkipModuleDiscovery.Description)
 	upgradeModuleCmd.PersistentFlags().BoolVarP(&params.SkipTenantEntitlement, action.SkipTenantEntitlement.Long, action.SkipTenantEntitlement.Short, false, action.SkipTenantEntitlement.Description)
+	upgradeModuleCmd.PersistentFlags().BoolVarP(&params.SkipRegistry, action.SkipRegistry.Long, action.SkipRegistry.Short, false, action.SkipRegistry.Description)
 
 	if err := upgradeModuleCmd.MarkPersistentFlagRequired(action.ModuleName.Long); err != nil {
 		slog.Error(errors.MarkFlagRequiredFailed(action.ModuleName, err).Error())

--- a/eureka-cli/constant/constant.go
+++ b/eureka-cli/constant/constant.go
@@ -130,6 +130,9 @@ const (
 	FolioRegistry  = "folio"
 	EurekaRegistry = "eureka"
 
+	// Files
+	ModulesFile = "modules.json"
+
 	// Docker compose properties
 	DockerComposeWorkDir = "./misc"
 

--- a/eureka-cli/internal/testhelpers/README.md
+++ b/eureka-cli/internal/testhelpers/README.md
@@ -22,9 +22,9 @@ HTTP testing utilities for mocking HTTP servers and responses:
 Mock implementations of key interfaces:
 
 - **MockHTTPClient**: Mock for `httpclient.HTTPClientRunner` interface
-- **MockAction**: Mock for `action.Action` struct
+- **NewMockAction()**: Returns a real `*action.Action` with an empty `Param` — set fields directly
 - **MockCommandExecutor**: Mock for `execsvc.CommandRunner` interface
-- **MockRegistrySvc**: Mock for `registrysvc.RegistryProcessor` interface
+- **MockRegistrySvc**: Mock for `registrysvc.RegistryProcessor` interface — `GetModules(verbose, forceRefresh bool)`
 - **MockModuleEnv**: Mock for `moduleenv.ModuleEnvProcessor` interface
 - **MockDockerClient**: Mock for `dockerclient.DockerClientRunner` interface
 - **MockTenantSvc**: Mock for `tenantsvc.TenantProcessor` interface
@@ -149,8 +149,9 @@ func TestSearchSvc_ReindexInventoryRecords(t *testing.T) {
 - Use descriptive test names
 - Test edge cases with empty strings and special characters
 - Verify URL parameter formatting and escaping
-- Remove TODO comments once tests are written
-- Run tests immediately after writing them
+- Use `_ = os.Remove(...)` / `_ = os.Rename(...)` in `t.Cleanup` closures to satisfy errcheck
+- Run `golangci-lint run ./...` once as the final finishing move
+- Target specific packages with `go test ./pkg/...` rather than `go test ./...`
 
 ❌ **DON'T**:
 
@@ -161,26 +162,27 @@ func TestSearchSvc_ReindexInventoryRecords(t *testing.T) {
 - Write flaky tests
 - Leave duplicate test function names
 - Forget to test error paths (headers, HTTP errors)
+- Run `go test ./...` across the whole module (RAM constrained)
 
 ## Running Tests
 
 ```bash
-# Run all tests
-go test ./...
+# Run specific package (preferred — machine is RAM-constrained)
+go test ./registrysvc/...
+go test ./cmd/...
 
-# Run with coverage
-go test -cover ./...
+# Run with race detection on a single package
+go test -race ./registrysvc/...
 
-# Run specific package
-go test ./searchsvc/...
+# Lint — run once as a finishing move
+golangci-lint run ./...
 
-# Run with race detection
-go test -race ./...
-
-# Generate coverage report
-go test -coverprofile=coverage.out ./...
+# Coverage for a single package
+go test -coverprofile=coverage.out ./registrysvc/...
 go tool cover -html=coverage.out
 ```
+
+> **Note**: Avoid `go test ./...` across the full module — it consumes significant RAM.
 
 ## Contributing
 

--- a/eureka-cli/internal/testhelpers/TESTING_GUIDE.md
+++ b/eureka-cli/internal/testhelpers/TESTING_GUIDE.md
@@ -326,17 +326,17 @@ require.NotNil(t, obj)
   - Application version retrieval (latest version queries)
   - Module discovery operations
 
-#### ModuleSvc Testing
+#### RegistrySvc Testing
 
-- **Focus**: Module provisioning and image management
-- **Mocks**: HTTPClient, RegistrySvc, ModuleEnv, DockerClient
+- **Focus**: LSP+FAR fetching, module partitioning, file persistence
+- **Mocks**: `MockHTTPClient`
 - **Key scenarios**:
-  - Module image formatting (standard, custom, local)
-  - Sidecar image resolution
-  - Environment variable configuration
-  - Module readiness checks
-  - Version resolution logic
-  - Edge cases with empty/special characters in parameters
+  - `GetModules(verbose, forceRefresh bool)` — both args required in every `.On()` call
+  - `forceRefresh=true`: fetch from network, write `~/modules.json`
+  - `forceRefresh=false` + file present: read local file, zero HTTP calls
+  - `SkipRegistry=true`: read local file, error if absent
+  - `t.Cleanup(func() { _ = os.Remove(filePath) })` — `_ =` required for errcheck
+  - FAR stubs use `[]any{map[string]any{...}}` not `[]map[string]any`
 
 #### HTTPClient Testing
 
@@ -375,28 +375,25 @@ func NewTestReindexJobResponseWithErrors(errors ...models.ReindexJobError) *mode
 ### 12. Running Tests
 
 ```bash
-# Run all tests
-go test ./...
-
-# Run tests with coverage
-go test -cover ./...
-
-# Run tests with verbose output
-go test -v ./...
-
-# Run specific package tests
-go test ./searchsvc/...
+# Run specific package (preferred — machine is RAM-constrained)
+go test ./registrysvc/...
+go test ./cmd/...
 
 # Run specific test
 go test ./searchsvc/ -run TestReindexInventoryRecords_Success
 
-# Run with race detection
-go test -race ./...
+# Run with race detection on a single package
+go test -race ./registrysvc/...
 
-# Generate coverage report
-go test -coverprofile=coverage.out ./...
+# Lint — run once as finishing move, not after every edit
+golangci-lint run ./...
+
+# Coverage for a single package
+go test -coverprofile=coverage.out ./registrysvc/...
 go tool cover -html=coverage.out
 ```
+
+> **Note**: Avoid `go test ./...` and `go test -cover ./...` across the full module — RAM-constrained machine.
 
 ### 13. Code Quality and Security Checks
 

--- a/eureka-cli/internal/testhelpers/mocks.go
+++ b/eureka-cli/internal/testhelpers/mocks.go
@@ -143,7 +143,7 @@ func (m *MockRegistrySvc) GetNamespace(version string) string {
 	return args.String(0)
 }
 
-func (m *MockRegistrySvc) ExtractModuleMetadata(modules *models.ProxyModulesByRegistry) {
+func (m *MockRegistrySvc) ResolveModuleMetadata(modules *models.ProxyModulesByRegistry) {
 	m.Called(modules)
 }
 
@@ -152,8 +152,8 @@ func (m *MockRegistrySvc) GetAuthorizationToken() (string, error) {
 	return args.String(0), args.Error(1)
 }
 
-func (m *MockRegistrySvc) GetModules(verbose bool) (*models.ProxyModulesByRegistry, error) {
-	args := m.Called(verbose)
+func (m *MockRegistrySvc) GetModules(verbose bool, forceRefresh bool) (*models.ProxyModulesByRegistry, error) {
+	args := m.Called(verbose, forceRefresh)
 	if args.Get(0) == nil {
 		return nil, args.Error(1)
 	}

--- a/eureka-cli/registrysvc/registry_svc.go
+++ b/eureka-cli/registrysvc/registry_svc.go
@@ -3,6 +3,8 @@ package registrysvc
 import (
 	"fmt"
 	"log/slog"
+	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 
@@ -18,8 +20,8 @@ import (
 // RegistryProcessor defines the interface for registry-related operations
 type RegistryProcessor interface {
 	GetNamespace(version string) string
-	GetModules(verbose bool) (*models.ProxyModulesByRegistry, error)
-	ExtractModuleMetadata(modules *models.ProxyModulesByRegistry)
+	GetModules(verbose bool, forceRefresh bool) (*models.ProxyModulesByRegistry, error)
+	ResolveModuleMetadata(modules *models.ProxyModulesByRegistry)
 	GetAuthorizationToken() (string, error)
 }
 
@@ -51,9 +53,9 @@ func (rs *RegistrySvc) GetNamespace(version string) string {
 	}
 }
 
-func (rs *RegistrySvc) ExtractModuleMetadata(modules *models.ProxyModulesByRegistry) {
-	allModules := [][]*models.ProxyModule{modules.FolioModules, modules.EurekaModules}
-	for _, moduleSet := range allModules {
+func (rs *RegistrySvc) ResolveModuleMetadata(modules *models.ProxyModulesByRegistry) {
+	moduleSets := [][]*models.ProxyModule{modules.FolioModules, modules.EurekaModules}
+	for _, moduleSet := range moduleSets {
 		for i, module := range moduleSet {
 			if module.ID == "okapi" {
 				continue
@@ -74,14 +76,14 @@ func (rs *RegistrySvc) getSidecarName(module *models.ProxyModule) string {
 	}
 }
 
-func (rs *RegistrySvc) GetModules(verbose bool) (*models.ProxyModulesByRegistry, error) {
-	allModules, err := rs.getFlattenedModuleVersions()
+func (rs *RegistrySvc) GetModules(verbose bool, forceRefresh bool) (*models.ProxyModulesByRegistry, error) {
+	moduleVersions, err := rs.getFlattenedModuleVersions(forceRefresh)
 	if err != nil {
 		return nil, err
 	}
 
 	var folioModules, eurekaModules []*models.ProxyModule
-	for _, m := range allModules {
+	for _, m := range moduleVersions {
 		proxy := &models.ProxyModule{
 			ID:     m.ID,
 			Action: "enable",
@@ -103,7 +105,43 @@ func (rs *RegistrySvc) GetModules(verbose bool) (*models.ProxyModulesByRegistry,
 	}, nil
 }
 
-func (rs *RegistrySvc) getFlattenedModuleVersions() ([]models.ApplicationModule, error) {
+func (rs *RegistrySvc) getFlattenedModuleVersions(forceRefresh bool) ([]models.ApplicationModule, error) {
+	homeDir, err := helpers.GetHomeDirPath()
+	if err != nil {
+		return nil, err
+	}
+	filePath := filepath.Join(homeDir, constant.ModulesFile)
+
+	if rs.Action.Param.SkipRegistry {
+		return rs.readModulesLocalFile(filePath)
+	}
+	if !forceRefresh {
+		if info, statErr := os.Stat(filePath); statErr == nil && info.Mode().IsRegular() {
+			return rs.readModulesLocalFile(filePath)
+		}
+	}
+
+	return rs.fetchAndPersistModuleVersions(filePath)
+}
+
+func (rs *RegistrySvc) readModulesLocalFile(path string) ([]models.ApplicationModule, error) {
+	if err := helpers.IsRegularFile(path); err != nil {
+		return nil, appErrors.LocalInstallFileNotFound(err)
+	}
+
+	var modules []models.ApplicationModule
+	if err := helpers.ReadJSONFromFile(path, &modules); err != nil {
+		return nil, err
+	}
+	if modules == nil {
+		modules = make([]models.ApplicationModule, 0)
+	}
+	slog.Info(rs.Action.Name, "text", "Read module versions from a local file", "file", constant.ModulesFile)
+
+	return modules, nil
+}
+
+func (rs *RegistrySvc) fetchAndPersistModuleVersions(filePath string) ([]models.ApplicationModule, error) {
 	var descriptor models.PlatformDescriptor
 	if err := rs.HTTPClient.GetRetryReturnStruct(rs.Action.ConfigLspURL, map[string]string{}, &descriptor); err != nil {
 		return nil, err
@@ -174,6 +212,15 @@ func (rs *RegistrySvc) getFlattenedModuleVersions() ([]models.ApplicationModule,
 		}
 		modules = append(modules, r.modules...)
 	}
+
+	if modules == nil {
+		modules = make([]models.ApplicationModule, 0)
+	}
+
+	if err := helpers.WriteJSONToFile(filePath, modules); err != nil {
+		return nil, err
+	}
+	slog.Info(rs.Action.Name, "text", "Persisted module versions to a local file", "file", constant.ModulesFile)
 
 	return modules, nil
 }

--- a/eureka-cli/registrysvc/registry_svc_test.go
+++ b/eureka-cli/registrysvc/registry_svc_test.go
@@ -2,14 +2,18 @@ package registrysvc_test
 
 import (
 	"errors"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/folio-org/eureka-setup/eureka-cli/constant"
+	"github.com/folio-org/eureka-setup/eureka-cli/helpers"
 	"github.com/folio-org/eureka-setup/eureka-cli/internal/testhelpers"
 	"github.com/folio-org/eureka-setup/eureka-cli/models"
 	"github.com/folio-org/eureka-setup/eureka-cli/registrysvc"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
 
 // MockAWSSvc is a mock for awssvc.AWSProcessor
@@ -194,7 +198,7 @@ func TestGetModules_Success(t *testing.T) {
 		map[string]any{"id": "mod-users-2.0.0", "name": "mod-users", "version": "2.0.0"},
 	})
 
-	result, err := svc.GetModules(false)
+	result, err := svc.GetModules(false, true)
 
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
@@ -220,7 +224,7 @@ func TestGetModules_Verbose(t *testing.T) {
 		map[string]any{"id": "mod-inventory-1.0.0", "name": "mod-inventory", "version": "1.0.0"},
 	})
 
-	result, err := svc.GetModules(true)
+	result, err := svc.GetModules(true, true)
 
 	assert.NoError(t, err)
 	assert.Len(t, result.FolioModules, 1)
@@ -238,7 +242,7 @@ func TestGetModules_LSPFetchError(t *testing.T) {
 	mockHTTP.On("GetRetryReturnStruct", act.ConfigLspURL, mock.Anything, mock.AnythingOfType("*models.PlatformDescriptor")).
 		Return(errors.New("LSP unreachable"))
 
-	result, err := svc.GetModules(false)
+	result, err := svc.GetModules(false, true)
 
 	assert.Error(t, err)
 	assert.Nil(t, result)
@@ -264,7 +268,7 @@ func TestGetModules_FARFetchError(t *testing.T) {
 	mockHTTP.On("GetRetryReturnStruct", farURL, mock.Anything, mock.AnythingOfType("*models.ApplicationsResponse")).
 		Return(errors.New("FAR timeout"))
 
-	result, err := svc.GetModules(false)
+	result, err := svc.GetModules(false, true)
 
 	assert.Error(t, err)
 	assert.Nil(t, result)
@@ -286,7 +290,7 @@ func TestGetModules_EurekaComponentsIncluded(t *testing.T) {
 	})
 	stubLSP(mockHTTP, act.ConfigLspURL, descriptor)
 
-	result, err := svc.GetModules(false)
+	result, err := svc.GetModules(false, true)
 
 	assert.NoError(t, err)
 	assert.Empty(t, result.FolioModules)
@@ -316,7 +320,7 @@ func TestGetModules_ModulePartitioning(t *testing.T) {
 		map[string]any{"id": "mod-scheduler-2.0.0", "name": "mod-scheduler", "version": "2.0.0"},
 	})
 
-	result, err := svc.GetModules(false)
+	result, err := svc.GetModules(false, true)
 
 	assert.NoError(t, err)
 	assert.Len(t, result.FolioModules, 1)
@@ -346,7 +350,7 @@ func TestGetModules_RequiredAndOptionalMerged(t *testing.T) {
 		map[string]any{"id": "mod-beta-2.0.0", "name": "mod-beta", "version": "2.0.0"},
 	})
 
-	result, err := svc.GetModules(false)
+	result, err := svc.GetModules(false, true)
 
 	assert.NoError(t, err)
 	assert.Len(t, result.FolioModules, 2)
@@ -376,7 +380,7 @@ func TestGetModules_ExperimentalAppsIncluded(t *testing.T) {
 		map[string]any{"id": "mod-inn-reach-3.0.0", "name": "mod-inn-reach", "version": "3.0.0"},
 	})
 
-	result, err := svc.GetModules(false)
+	result, err := svc.GetModules(false, true)
 
 	assert.NoError(t, err)
 	assert.Len(t, result.FolioModules, 3)
@@ -407,7 +411,7 @@ func TestGetModules_UIModulesIncluded(t *testing.T) {
 		},
 	)
 
-	result, err := svc.GetModules(false)
+	result, err := svc.GetModules(false, true)
 
 	assert.NoError(t, err)
 	assert.Len(t, result.FolioModules, 3)
@@ -428,7 +432,7 @@ func TestGetModules_EmptyApplications(t *testing.T) {
 	})
 	stubLSP(mockHTTP, act.ConfigLspURL, descriptor)
 
-	result, err := svc.GetModules(false)
+	result, err := svc.GetModules(false, true)
 
 	assert.NoError(t, err)
 	assert.Empty(t, result.FolioModules)
@@ -455,7 +459,7 @@ func TestIsEurekaModule_KeycloakSuffix(t *testing.T) {
 		map[string]any{"id": "mod-auth-keycloak-1.0.0", "name": "mod-auth-keycloak", "version": "1.0.0"},
 	})
 
-	result, err := svc.GetModules(false)
+	result, err := svc.GetModules(false, true)
 	assert.NoError(t, err)
 	assert.Empty(t, result.FolioModules)
 	assert.Len(t, result.EurekaModules, 1)
@@ -479,7 +483,7 @@ func TestIsEurekaModule_MgrPrefix(t *testing.T) {
 		map[string]any{"id": "mgr-tenants-1.0.0", "name": "mgr-tenants", "version": "1.0.0"},
 	})
 
-	result, err := svc.GetModules(false)
+	result, err := svc.GetModules(false, true)
 	assert.NoError(t, err)
 	assert.Empty(t, result.FolioModules)
 	assert.Len(t, result.EurekaModules, 2)
@@ -504,7 +508,7 @@ func TestIsEurekaModule_ExactMatches(t *testing.T) {
 		map[string]any{"id": "mod-scheduler-2.0.0", "name": "mod-scheduler", "version": "2.0.0"},
 	})
 
-	result, err := svc.GetModules(false)
+	result, err := svc.GetModules(false, true)
 	assert.NoError(t, err)
 	assert.Empty(t, result.FolioModules)
 	assert.Len(t, result.EurekaModules, 3)
@@ -529,13 +533,13 @@ func TestIsEurekaModule_RegularFolioModuleNotEureka(t *testing.T) {
 		map[string]any{"id": "edge-patron-1.0.0", "name": "edge-patron", "version": "1.0.0"},
 	})
 
-	result, err := svc.GetModules(false)
+	result, err := svc.GetModules(false, true)
 	assert.NoError(t, err)
 	assert.Len(t, result.FolioModules, 3)
 	assert.Empty(t, result.EurekaModules)
 }
 
-func TestExtractModuleMetadata_Success(t *testing.T) {
+func TestResolveModuleMetadata_Success(t *testing.T) {
 	// Arrange
 	mockHTTP := &testhelpers.MockHTTPClient{}
 	mockAWS := &MockAWSSvc{}
@@ -556,7 +560,7 @@ func TestExtractModuleMetadata_Success(t *testing.T) {
 	}
 
 	// Act
-	svc.ExtractModuleMetadata(modules)
+	svc.ResolveModuleMetadata(modules)
 
 	// Assert
 	// Check FOLIO modules
@@ -575,7 +579,7 @@ func TestExtractModuleMetadata_Success(t *testing.T) {
 	assert.Equal(t, "mod-custom-sc", modules.EurekaModules[0].Metadata.SidecarName)
 }
 
-func TestExtractModuleMetadata_EdgeModule(t *testing.T) {
+func TestResolveModuleMetadata_EdgeModule(t *testing.T) {
 	// Arrange
 	mockHTTP := &testhelpers.MockHTTPClient{}
 	mockAWS := &MockAWSSvc{}
@@ -590,7 +594,7 @@ func TestExtractModuleMetadata_EdgeModule(t *testing.T) {
 	}
 
 	// Act
-	svc.ExtractModuleMetadata(modules)
+	svc.ResolveModuleMetadata(modules)
 
 	// Assert
 	// Edge modules should have SidecarName equal to Name
@@ -598,7 +602,7 @@ func TestExtractModuleMetadata_EdgeModule(t *testing.T) {
 	assert.Equal(t, "edge-patron", modules.FolioModules[0].Metadata.SidecarName)
 }
 
-func TestExtractModuleMetadata_SkipsOkapi(t *testing.T) {
+func TestResolveModuleMetadata_SkipsOkapi(t *testing.T) {
 	// Arrange
 	mockHTTP := &testhelpers.MockHTTPClient{}
 	mockAWS := &MockAWSSvc{}
@@ -614,7 +618,7 @@ func TestExtractModuleMetadata_SkipsOkapi(t *testing.T) {
 	}
 
 	// Act
-	svc.ExtractModuleMetadata(modules)
+	svc.ResolveModuleMetadata(modules)
 
 	// Assert
 	// Okapi should remain unchanged
@@ -626,7 +630,7 @@ func TestExtractModuleMetadata_SkipsOkapi(t *testing.T) {
 	assert.Equal(t, "mod-users", modules.FolioModules[1].Metadata.Name)
 }
 
-func TestExtractModuleMetadata_EmptyModules(t *testing.T) {
+func TestResolveModuleMetadata_EmptyModules(t *testing.T) {
 	// Arrange
 	mockHTTP := &testhelpers.MockHTTPClient{}
 	mockAWS := &MockAWSSvc{}
@@ -636,10 +640,10 @@ func TestExtractModuleMetadata_EmptyModules(t *testing.T) {
 	modules := &models.ProxyModulesByRegistry{FolioModules: nil, EurekaModules: nil}
 
 	// Act & Assert - should not panic
-	svc.ExtractModuleMetadata(modules)
+	svc.ResolveModuleMetadata(modules)
 }
 
-func TestExtractModuleMetadata_ModuleWithoutVersion(t *testing.T) {
+func TestResolveModuleMetadata_ModuleWithoutVersion(t *testing.T) {
 	// Arrange
 	mockHTTP := &testhelpers.MockHTTPClient{}
 	mockAWS := &MockAWSSvc{}
@@ -654,7 +658,7 @@ func TestExtractModuleMetadata_ModuleWithoutVersion(t *testing.T) {
 	}
 
 	// Act
-	svc.ExtractModuleMetadata(modules)
+	svc.ResolveModuleMetadata(modules)
 
 	// Assert
 	// When module ID doesn't have a proper version, the regex parsing behavior
@@ -681,7 +685,7 @@ func TestGetSidecarName_StandardModule(t *testing.T) {
 		}
 
 		// Act
-		svc.ExtractModuleMetadata(&models.ProxyModulesByRegistry{
+		svc.ResolveModuleMetadata(&models.ProxyModulesByRegistry{
 			FolioModules: []*models.ProxyModule{module},
 		})
 
@@ -704,7 +708,7 @@ func TestGetSidecarName_EdgeModule(t *testing.T) {
 		}
 
 		// Act
-		svc.ExtractModuleMetadata(&models.ProxyModulesByRegistry{
+		svc.ResolveModuleMetadata(&models.ProxyModulesByRegistry{
 			FolioModules: []*models.ProxyModule{module},
 		})
 
@@ -727,7 +731,7 @@ func TestGetSidecarName_EdgeOaiPmhModule(t *testing.T) {
 		}
 
 		// Act
-		svc.ExtractModuleMetadata(&models.ProxyModulesByRegistry{
+		svc.ResolveModuleMetadata(&models.ProxyModulesByRegistry{
 			EurekaModules: []*models.ProxyModule{module},
 		})
 
@@ -750,7 +754,7 @@ func TestGetSidecarName_EdgeRtacModule(t *testing.T) {
 		}
 
 		// Act
-		svc.ExtractModuleMetadata(&models.ProxyModulesByRegistry{
+		svc.ResolveModuleMetadata(&models.ProxyModulesByRegistry{
 			FolioModules: []*models.ProxyModule{module},
 		})
 
@@ -773,7 +777,7 @@ func TestGetSidecarName_NonEdgeModuleContainingEdge(t *testing.T) {
 		}
 
 		// Act
-		svc.ExtractModuleMetadata(&models.ProxyModulesByRegistry{
+		svc.ResolveModuleMetadata(&models.ProxyModulesByRegistry{
 			FolioModules: []*models.ProxyModule{module},
 		})
 
@@ -800,11 +804,134 @@ func TestGetSidecarName_MultipleEdgeModules(t *testing.T) {
 		}
 
 		// Act
-		svc.ExtractModuleMetadata(modules)
+		svc.ResolveModuleMetadata(modules)
 
 		// Assert - verify all edge modules use name without -sc, non-edge use -sc
 		assert.Equal(t, "edge-patron", modules.FolioModules[0].Metadata.SidecarName)
 		assert.Equal(t, "edge-orders", modules.FolioModules[1].Metadata.SidecarName)
 		assert.Equal(t, "mod-users-sc", modules.FolioModules[2].Metadata.SidecarName)
 	})
+}
+
+// ==================== Persistence Tests ====================
+
+func modulesFilePath(t *testing.T) string {
+	t.Helper()
+	homeDir, err := helpers.GetHomeDirPath()
+	require.NoError(t, err)
+	return filepath.Join(homeDir, constant.ModulesFile)
+}
+
+func TestGetModules_SkipRegistry_ReadsLocalFile(t *testing.T) {
+	filePath := modulesFilePath(t)
+
+	known := []models.ApplicationModule{
+		{ID: "mod-inventory-1.0.0", Name: "mod-inventory", Version: "1.0.0"},
+		{ID: "mgr-tenants-2.0.0", Name: "mgr-tenants", Version: "2.0.0"},
+	}
+	require.NoError(t, helpers.WriteJSONToFile(filePath, known))
+	t.Cleanup(func() { _ = os.Remove(filePath) })
+
+	mockHTTP := &testhelpers.MockHTTPClient{}
+	mockAWS := &MockAWSSvc{}
+	act := testhelpers.NewMockAction()
+	act.Param.SkipRegistry = true
+	svc := registrysvc.New(act, mockHTTP, mockAWS)
+
+	result, err := svc.GetModules(false, false)
+
+	assert.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Len(t, result.FolioModules, 1)
+	assert.Len(t, result.EurekaModules, 1)
+	assert.Equal(t, "mod-inventory-1.0.0", result.FolioModules[0].ID)
+	assert.Equal(t, "mgr-tenants-2.0.0", result.EurekaModules[0].ID)
+	mockHTTP.AssertNotCalled(t, "GetRetryReturnStruct", mock.Anything, mock.Anything, mock.Anything)
+}
+
+func TestGetModules_SkipRegistry_MissingFile(t *testing.T) {
+	filePath := modulesFilePath(t)
+
+	// Temporarily move the file aside if it exists so we get a clean miss
+	backup := filePath + ".bak"
+	if _, err := os.Stat(filePath); err == nil {
+		require.NoError(t, os.Rename(filePath, backup))
+		t.Cleanup(func() { _ = os.Rename(backup, filePath) })
+	}
+
+	mockHTTP := &testhelpers.MockHTTPClient{}
+	mockAWS := &MockAWSSvc{}
+	act := testhelpers.NewMockAction()
+	act.Param.SkipRegistry = true
+	svc := registrysvc.New(act, mockHTTP, mockAWS)
+
+	result, err := svc.GetModules(false, false)
+
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "failed to find local install file")
+	mockHTTP.AssertNotCalled(t, "GetRetryReturnStruct", mock.Anything, mock.Anything, mock.Anything)
+}
+
+func TestGetModules_FetchAndPersistWritesFile(t *testing.T) {
+	filePath := modulesFilePath(t)
+	t.Cleanup(func() { _ = os.Remove(filePath) })
+
+	mockHTTP := &testhelpers.MockHTTPClient{}
+	mockAWS := &MockAWSSvc{}
+	act := testhelpers.NewMockAction()
+	act.ConfigLspURL = "http://lsp.example.com/descriptor.json"
+	act.ConfigFarURL = "http://far.example.com"
+	svc := registrysvc.New(act, mockHTTP, mockAWS)
+
+	descriptor := buildLSPResponse(
+		[]models.PlatformApplication{{Name: "app-core", Version: "1.0.0"}},
+		nil, nil, nil,
+	)
+	stubLSP(mockHTTP, act.ConfigLspURL, descriptor)
+	stubFAR(mockHTTP, act.ConfigFarURL, "app-core", "1.0.0", []any{
+		map[string]any{"id": "mod-inventory-1.0.0", "name": "mod-inventory", "version": "1.0.0"},
+		map[string]any{"id": "mod-users-2.0.0", "name": "mod-users", "version": "2.0.0"},
+	})
+
+	_, err := svc.GetModules(false, true)
+	require.NoError(t, err)
+
+	var persisted []models.ApplicationModule
+	require.NoError(t, helpers.ReadJSONFromFile(filePath, &persisted))
+	assert.Len(t, persisted, 2)
+	assert.Equal(t, "mod-inventory-1.0.0", persisted[0].ID)
+	assert.Equal(t, "mod-inventory", persisted[0].Name)
+	assert.Equal(t, "1.0.0", persisted[0].Version)
+	assert.Equal(t, "mod-users-2.0.0", persisted[1].ID)
+	mockHTTP.AssertExpectations(t)
+}
+
+func TestGetModules_PreferLocalWhenFileExists(t *testing.T) {
+	filePath := modulesFilePath(t)
+
+	known := []models.ApplicationModule{
+		{ID: "mod-search-3.0.0", Name: "mod-search", Version: "3.0.0"},
+		{ID: "mgr-applications-1.5.0", Name: "mgr-applications", Version: "1.5.0"},
+	}
+	require.NoError(t, helpers.WriteJSONToFile(filePath, known))
+	t.Cleanup(func() { _ = os.Remove(filePath) })
+
+	mockHTTP := &testhelpers.MockHTTPClient{}
+	mockAWS := &MockAWSSvc{}
+	act := testhelpers.NewMockAction()
+	act.ConfigLspURL = "http://lsp.example.com/descriptor.json"
+	act.ConfigFarURL = "http://far.example.com"
+	// SkipRegistry=false, forceRefresh=false — intercept/upgrade path
+	svc := registrysvc.New(act, mockHTTP, mockAWS)
+
+	result, err := svc.GetModules(false, false)
+
+	assert.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Len(t, result.FolioModules, 1)
+	assert.Len(t, result.EurekaModules, 1)
+	assert.Equal(t, "mod-search-3.0.0", result.FolioModules[0].ID)
+	assert.Equal(t, "mgr-applications-1.5.0", result.EurekaModules[0].ID)
+	mockHTTP.AssertNotCalled(t, "GetRetryReturnStruct", mock.Anything, mock.Anything, mock.Anything)
 }


### PR DESCRIPTION
## Purpose

- <https://folio-org.atlassian.net/browse/ECLI-23>

## Approach

- Add persistence of module versions fetched from LSP and FAR
- These changes will prevent unsuspected missing module errors during module interception/upgrade
- Updates tests, AGENTS.md and internal/ package resources