### PR TITLE
[ECLI-3]. Add command idempotency and deployment resumption

### DIFF
--- a/eureka-cli/AGENTS.md
+++ b/eureka-cli/AGENTS.md
@@ -7,15 +7,39 @@ Module: `github.com/folio-org/eureka-setup/eureka-cli`
 
 ## Key architecture
 
-| Layer         | Package                 | Responsibility                                                               |
-| ------------- | ----------------------- | -----------------------------------------------------------------------------|
-| Entry point   | `main.go` + `cmd/`      | Cobra commands, flag parsing, wiring services                                |
-| Shared state  | `action/`               | `Action` struct — holds all config values from Viper                         |
-| Config fields | `field/`                | String constants for Viper keys (`lsp.url`, `far.url`, `registry.url`, …)    |
-| Registry      | `registrysvc/`          | Fetches module lists from LSP/FAR, partitions folio/eureka                   |
-| Models        | `models/`               | Shared structs — `ProxyModule`, `ApplicationModule`, `PlatformDescriptor`, … |
-| HTTP          | `httpclient/`           | `HTTPClientRunner` interface + retry wrapper                                 |
-| Test helpers  | `internal/testhelpers/` | `MockHTTPClient`, `MockRegistrySvc`, `NewMockAction()`                       |
+| Layer              | Package                  | Responsibility                                                                           |
+|:-------------------|:-------------------------|:-----------------------------------------------------------------------------------------|
+| Entry point        | `main.go` + `cmd/`       | Cobra commands, flag parsing, wiring services via `runconfig.New`                        |
+| Shared state       | `action/`                | `Action` struct — holds all config values from Viper                                     |
+| Config fields      | `field/`                 | String constants for all Viper keys — never use raw strings in `viper.Get*`              |
+| Run config         | `runconfig/`             | `RunConfig{*Infrastructure, *Services}` wired by DI at startup                           |
+| Registry           | `registrysvc/`           | Fetches module lists from LSP/FAR, partitions folio/eureka, persists to `~/modules.json` |
+| Module deploy      | `modulesvc/`             | Pull, deploy, undeploy, readiness; split across `module_svc*.go` files                   |
+| Management API     | `managementsvc/`         | mgr-* API calls: tenants, entitlements, applications, discovery                          |
+| Keycloak           | `keycloaksvc/`           | Keycloak admin: users, roles, capability sets, tokens                                    |
+| Kong               | `kongsvc/`               | Kong route reads + readiness check                                                       |
+| UI                 | `uisvc/`                 | UI Docker container deploy + stripes config/package.json generation                      |
+| Intercept module   | `interceptmodulesvc/`    | Intercept and redirect module traffic (telepresence-style)                               |
+| Upgrade module     | `upgrademodulesvc/`      | Deploy upgraded/downgraded module version + sidecar                                      |
+| Consortium         | `consortiumsvc/`         | Consortium/ECS management: entitlements, central ordering                                |
+| Tenant             | `tenantsvc/`             | Tenant configuration and parameter management                                            |
+| User               | `usersvc/`               | User CRUD operations                                                                     |
+| Search             | `searchsvc/`             | Elasticsearch reindex operations                                                         |
+| Kafka              | `kafkasvc/`              | Kafka health checks and consumer lag monitoring                                          |
+| AWS                | `awssvc/`                | AWS ECR registry authentication                                                          |
+| HTTP               | `httpclient/`            | `HTTPClientRunner` interface + retry wrapper                                             |
+| Exec               | `execsvc/`               | Shell exec wrapper: `Exec`, `ExecReturnOutput`, `ExecFromDir`                            |
+| Docker client      | `dockerclient/`          | Docker client factory + image push/pull helpers                                          |
+| Vault client       | `vaultclient/`           | HashiCorp Vault API client                                                               |
+| Git client         | `gitclient/`             | Git clone/pull operations                                                                |
+| Git repository     | `gitrepository/`         | `GitRepository` data model for git repo metadata                                         |
+| Module props       | `moduleprops/`           | Reads `config.*.yaml` into `BackendModule` / `FrontendModule` maps                       |
+| Module env         | `moduleenv/`             | Per-module environment variable resolution                                               |
+| Models             | `models/`                | Shared data types: `BackendModule`, `Container`, `ProxyModule`, etc.                     |
+| Helpers            | `helpers/`               | Pure utility functions (memory conversion, restart policy, etc.)                         |
+| Errors             | `errors/`                | Typed error factory functions — all call sites import this, never `fmt.Errorf`           |
+| Constants          | `constant/`              | Package-level constants (timeouts, patterns, network IDs)                                |
+| Test helpers       | `internal/testhelpers/`  | Shared mocks and HTTP/file helpers — test use only                                       |
 
 ## Module source of truth
 
@@ -54,10 +78,26 @@ Everything else is a FOLIO module.
 ## `Action` struct fields (relevant subset)
 
 ```go
-ConfigLspURL      string  // viper: lsp.url
-ConfigFarURL      string  // viper: far.url
-ConfigRegistryURL string  // viper: registry.url  — keep for listModuleVersions
+ConfigProfileName  string  // viper: profile.name  — container name prefix for non-mgr modules
+ConfigLspURL       string  // viper: lsp.url
+ConfigFarURL       string  // viper: far.url
+ConfigRegistryURL  string  // viper: registry.url  — keep for listModuleVersions
 ```
+
+## `field/` package
+
+All Viper keys are constants in `field/`. Never use raw string literals in `viper.GetString()` or `viper.Get()`.
+
+```go
+viper.GetString(field.ProfileName)     // "profile.name"
+viper.GetString(field.LspURL)          // "lsp.url"
+viper.GetString(field.FarURL)          // "far.url"
+viper.GetString(field.RegistryURL)     // "registry.url"
+viper.Get(field.BackendModules)        // "backend-modules"
+viper.Get(field.FrontendModules)       // "frontend-modules"
+```
+
+Key groups: `Profile`, `Application`, `Lsp`, `Far`, `Registry`, `Tenants`, `Users`, `Roles`, `Consortiums`, `BackendModules`, `FrontendModules`, `SidecarModule`, `ExtraVolumes`, `TemplateEnv`.
 
 ## FAR response shape
 
@@ -99,6 +139,17 @@ Pre-allocated slice with per-goroutine index — no mutex needed.
 - Persistence tests write/read `~/modules.json` directly; use `t.Cleanup(func() { _ = os.Remove(filePath) })` — note the `_ =` to satisfy errcheck
 - Do NOT run `go test ./...` (RAM constrained) — target only affected packages
 - Run `golangci-lint run ./...` once as a finishing move, not after every edit
+
+### Two exec mock types — do not confuse
+
+`execsvc.CommandRunner` has three methods: `Exec`, `ExecReturnOutput`, `ExecFromDir`.
+
+| Type                              | Location                            | Use                                                      |
+|:----------------------------------|:------------------------------------|:---------------------------------------------------------|
+| `testhelpers.MockCommandExecutor` | `internal/testhelpers/mocks.go`     | Service package tests (`uisvc/`, `dockerclient/`, etc.)  |
+| `MockExecSvc`                     | `cmd/cmd_test.go`                   | `cmd/` tests only                                        |
+
+`MockCommandExecutor` also has `ExecIgnoreError` as an extra method not present in `CommandRunner` — ignore it when mocking the interface.
 
 ## Interface
 

--- a/eureka-cli/cmd/attachCapabilitySets.go
+++ b/eureka-cli/cmd/attachCapabilitySets.go
@@ -53,11 +53,21 @@ func (run *Run) AttachCapabilitySets(consortiumName string, tenantType constant.
 		if err := run.updateRealmAccessTokenSettingsAndRelogin(configTenant); err != nil {
 			return err
 		}
-		topicConfigTenant := run.Config.Action.GetKafkaTopicConfigTenant(configTenant)
 
-		slog.Info(run.Config.Action.Name, "text", "POLLING FOR CAPABILITY SETS CREATION", "topicConfigTenant", topicConfigTenant)
-		if err := run.Config.KafkaSvc.PollConsumerGroup(topicConfigTenant); err != nil {
+		slog.Info(run.Config.Action.Name, "text", "CHECKING IF CAPABILITY SETS ALREADY EXIST", "tenant", configTenant)
+		hasCapabilitySets, err := run.Config.KeycloakSvc.HasCapabilitySets(configTenant)
+		if err != nil {
 			return err
+		}
+
+		if !hasCapabilitySets {
+			topicConfigTenant := run.Config.Action.GetKafkaTopicConfigTenant(configTenant)
+			slog.Info(run.Config.Action.Name, "text", "POLLING FOR CAPABILITY SETS CREATION", "topicConfigTenant", topicConfigTenant)
+			if err := run.Config.KafkaSvc.PollConsumerGroup(topicConfigTenant); err != nil {
+				return err
+			}
+		} else {
+			slog.Info(run.Config.Action.Name, "text", "Capability sets already exist, skipping Kafka poll", "tenant", configTenant)
 		}
 
 		slog.Info(run.Config.Action.Name, "text", "ATTACHING CAPABILITY SETS", "tenant", configTenant)

--- a/eureka-cli/cmd/cmd_additional_test.go
+++ b/eureka-cli/cmd/cmd_additional_test.go
@@ -215,7 +215,7 @@ func TestDeployManagement_Success(t *testing.T) {
 	mockDocker.On("Create").Return(nil, nil)
 	mockModule.On("GetVaultRootToken", mock.Anything).Return("", nil)
 	mockModule.On("DeployModules", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
-		Return(map[string]int{"test-module": 8080}, nil)
+		Return(map[string]int{"test-module": 8080}, 1, nil)
 	mockModule.On("CheckModuleReadiness", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
 	mockKongSvc.On("CheckRouteReadiness").Return(nil)
 	mockKeycloak.On("GetMasterAccessToken", mock.Anything).Return("access-token", nil)
@@ -244,7 +244,7 @@ func TestDeployManagement_DeployModulesError(t *testing.T) {
 	mockRegistrySvc.On("ResolveModuleMetadata", mock.Anything).Return()
 	mockDocker.On("Create").Return(nil, nil)
 	mockModule.On("GetVaultRootToken", mock.Anything).Return("", nil)
-	mockModule.On("DeployModules", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, expectedError)
+	mockModule.On("DeployModules", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, 0, expectedError)
 	mockDocker.On("Close", mock.Anything).Return(nil)
 
 	// Act
@@ -269,7 +269,7 @@ func TestDeployManagement_NoModulesDeployed(t *testing.T) {
 	mockDocker.On("Create").Return(nil, nil)
 	mockModule.On("GetVaultRootToken", mock.Anything).Return("", nil)
 	mockModule.On("DeployModules", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
-		Return(map[string]int{}, nil)
+		Return(map[string]int{}, 0, nil)
 	mockDocker.On("Close", mock.Anything).Return(nil)
 
 	// Act
@@ -278,6 +278,34 @@ func TestDeployManagement_NoModulesDeployed(t *testing.T) {
 	// Assert
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "modules not deployed")
+}
+
+func TestDeployManagement_AllAlreadyDeployed_SkipsHealthcheck(t *testing.T) {
+	// Arrange
+	run, _, mockKeycloak, _, mockDocker, mockModule := newTestRun(action.DeployManagement)
+	mockModuleProps := &MockModuleProps{}
+	mockRegistrySvc := &MockRegistrySvc{}
+	run.Config.ModuleProps = mockModuleProps
+	run.Config.RegistrySvc = mockRegistrySvc
+
+	mockModuleProps.On("ReadBackendModules", true, true).Return(map[string]models.BackendModule{}, nil)
+	mockRegistrySvc.On("GetModules", true, true).Return(&models.ProxyModulesByRegistry{}, nil)
+	mockRegistrySvc.On("ResolveModuleMetadata", mock.Anything).Return()
+	mockDocker.On("Create").Return(nil, nil)
+	mockModule.On("GetVaultRootToken", mock.Anything).Return("", nil)
+	// newlyDeployed=empty (all already existed), totalMatched=1
+	mockModule.On("DeployModules", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return(map[string]int{}, 1, nil)
+	mockKeycloak.On("GetMasterAccessToken", mock.Anything).Return("access-token", nil)
+	mockKeycloak.On("UpdateRealmAccessTokenSettings", constant.KeycloakMasterRealm, mock.Anything).Return(nil)
+	mockDocker.On("Close", mock.Anything).Return(nil)
+
+	// Act
+	err := run.DeployManagement()
+
+	// Assert — no healthcheck, no kong check
+	assert.NoError(t, err)
+	mockModule.AssertNotCalled(t, "CheckModuleReadiness")
 }
 
 // ==================== UndeployManagement Tests ====================

--- a/eureka-cli/cmd/cmd_test.go
+++ b/eureka-cli/cmd/cmd_test.go
@@ -210,6 +210,11 @@ func (m *MockKeycloakSvc) GetCapabilitySetsByName(headers map[string]string, cap
 	return args.Get(0).([]any), args.Error(1)
 }
 
+func (m *MockKeycloakSvc) HasCapabilitySets(tenantName string) (bool, error) {
+	args := m.Called(tenantName)
+	return args.Bool(0), args.Error(1)
+}
+
 func (m *MockKeycloakSvc) AttachCapabilitySets(tenantName string) error {
 	args := m.Called(tenantName)
 	return args.Error(0)
@@ -350,17 +355,25 @@ func (m *MockModuleSvc) GetDeployedModules(cli *client.Client, f filters.Args) (
 	return args.Get(0).([]container.Summary), args.Error(1)
 }
 
+func (m *MockModuleSvc) GetModule(cli *client.Client, moduleName string) ([]container.Summary, error) {
+	args := m.Called(cli, moduleName)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]container.Summary), args.Error(1)
+}
+
 func (m *MockModuleSvc) PullModule(cli *client.Client, imageName string) error {
 	args := m.Called(cli, imageName)
 	return args.Error(0)
 }
 
-func (m *MockModuleSvc) DeployModules(cli *client.Client, containers *models.Containers, sidecarImage string, sidecarResources *container.Resources) (map[string]int, error) {
+func (m *MockModuleSvc) DeployModules(cli *client.Client, containers *models.Containers, sidecarImage string, sidecarResources *container.Resources) (map[string]int, int, error) {
 	args := m.Called(cli, containers, sidecarImage, sidecarResources)
 	if args.Get(0) == nil {
-		return nil, args.Error(1)
+		return nil, args.Int(1), args.Error(2)
 	}
-	return args.Get(0).(map[string]int), args.Error(1)
+	return args.Get(0).(map[string]int), args.Int(1), args.Error(2)
 }
 
 func (m *MockModuleSvc) DeployModule(cli *client.Client, container *models.Container) error {
@@ -1609,6 +1622,7 @@ func TestAttachCapabilitySets_Success(t *testing.T) {
 		Return([]any{map[string]any{"name": "test-tenant", "description": "nop-default"}}, nil)
 	mockKeycloak.On("UpdateRealmAccessTokenSettings", mock.Anything, mock.Anything).Return(nil)
 	mockKeycloak.On("GetAccessToken", mock.Anything).Return("", nil)
+	mockKeycloak.On("HasCapabilitySets", "test-tenant").Return(false, nil)
 	mockKafkaSvc.On("PollConsumerGroup", mock.Anything).Return(nil)
 	mockKeycloak.On("AttachCapabilitySetsToRoles", "test-tenant").Return(nil)
 
@@ -1619,6 +1633,31 @@ func TestAttachCapabilitySets_Success(t *testing.T) {
 	assert.NoError(t, err)
 	mockKeycloak.AssertExpectations(t)
 	mockKafkaSvc.AssertExpectations(t)
+}
+
+func TestAttachCapabilitySets_AlreadyExist_SkipsPoll(t *testing.T) {
+	// Arrange
+	run, mockManagement, mockKeycloak, _, mockDocker, mockModule := newTestRun(action.AttachCapabilitySets)
+	mockKafkaSvc := &MockKafkaSvc{}
+	run.Config.KafkaSvc = mockKafkaSvc
+
+	mockDocker.On("Create").Return(nil, nil)
+	mockModule.On("GetVaultRootToken", mock.Anything).Return("", nil)
+	mockKeycloak.On("GetMasterAccessToken", mock.AnythingOfType("constant.KeycloakGrantType")).Return("", nil)
+	mockManagement.On("GetTenants", mock.Anything, mock.Anything).
+		Return([]any{map[string]any{"name": "test-tenant", "description": "nop-default"}}, nil)
+	mockKeycloak.On("UpdateRealmAccessTokenSettings", mock.Anything, mock.Anything).Return(nil)
+	mockKeycloak.On("GetAccessToken", mock.Anything).Return("", nil)
+	mockKeycloak.On("HasCapabilitySets", "test-tenant").Return(true, nil)
+	mockKeycloak.On("AttachCapabilitySetsToRoles", "test-tenant").Return(nil)
+
+	// Act
+	err := run.AttachCapabilitySets(constant.NoneConsortium, constant.Default, 0)
+
+	// Assert
+	assert.NoError(t, err)
+	mockKeycloak.AssertExpectations(t)
+	mockKafkaSvc.AssertNotCalled(t, "PollConsumerGroup", mock.Anything)
 }
 
 func TestAttachCapabilitySets_GetMasterTokenError(t *testing.T) {
@@ -1673,6 +1712,7 @@ func TestAttachCapabilitySets_AttachError(t *testing.T) {
 		Return([]any{map[string]any{"name": "test-tenant", "description": "nop-default"}}, nil)
 	mockKeycloak.On("UpdateRealmAccessTokenSettings", mock.Anything, mock.Anything).Return(nil)
 	mockKeycloak.On("GetAccessToken", mock.Anything).Return("", nil)
+	mockKeycloak.On("HasCapabilitySets", "test-tenant").Return(false, nil)
 	mockKafkaSvc.On("PollConsumerGroup", mock.Anything).Return(nil)
 	mockKeycloak.On("AttachCapabilitySetsToRoles", "test-tenant").Return(expectedError)
 
@@ -2278,7 +2318,7 @@ func TestDeployModules_Success(t *testing.T) {
 	mockDocker.On("Create").Return(nil, nil)
 	mockModule.On("GetVaultRootToken", mock.Anything).Return("", nil)
 	mockModule.On("GetSidecarImage", mock.Anything).Return("test-sidecar:latest", false, nil)
-	mockModule.On("DeployModules", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(map[string]int{"test-module": 8080}, nil)
+	mockModule.On("DeployModules", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(map[string]int{"test-module": 8080}, 1, nil)
 	mockModule.On("CheckModuleReadiness", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
 	mockKeycloak.On("GetMasterAccessToken", mock.Anything).Return("access-token", nil)
 	mockManagement.On("CreateApplication", mock.Anything).Return(nil)
@@ -2291,7 +2331,34 @@ func TestDeployModules_Success(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-// ==================== DeploySystem Tests ====================
+func TestDeployModules_AllAlreadyDeployed_SkipsHealthcheck(t *testing.T) {
+	// Arrange
+	run, mockManagement, mockKeycloak, _, mockDocker, mockModule := newTestRun(action.DeployModules)
+	mockModuleProps := &MockModuleProps{}
+	mockRegistrySvc := &MockRegistrySvc{}
+	run.Config.ModuleProps = mockModuleProps
+	run.Config.RegistrySvc = mockRegistrySvc
+
+	mockModuleProps.On("ReadBackendModules", false, true).Return(map[string]models.BackendModule{}, nil)
+	mockModuleProps.On("ReadFrontendModules", true).Return(map[string]models.FrontendModule{}, nil)
+	mockRegistrySvc.On("GetModules", true, true).Return(&models.ProxyModulesByRegistry{}, nil)
+	mockRegistrySvc.On("ResolveModuleMetadata", mock.Anything).Return()
+	mockDocker.On("Create").Return(nil, nil)
+	mockModule.On("GetVaultRootToken", mock.Anything).Return("", nil)
+	mockModule.On("GetSidecarImage", mock.Anything).Return("test-sidecar:latest", false, nil)
+	// newlyDeployed=empty (all already existed), totalMatched=2
+	mockModule.On("DeployModules", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(map[string]int{}, 2, nil)
+	mockKeycloak.On("GetMasterAccessToken", mock.Anything).Return("access-token", nil)
+	mockManagement.On("CreateApplication", mock.Anything).Return(nil)
+	mockDocker.On("Close", mock.Anything).Return(nil)
+
+	// Act
+	err := run.DeployModules()
+
+	// Assert — no CheckModuleReadiness call
+	assert.NoError(t, err)
+	mockModule.AssertNotCalled(t, "CheckModuleReadiness")
+}
 
 func TestDeploySystem_Success(t *testing.T) {
 	// Arrange
@@ -2305,7 +2372,31 @@ func TestDeploySystem_Success(t *testing.T) {
 	mockGitClient.On("KongRepository").Return(&gitrepository.GitRepository{}, nil)
 	mockGitClient.On("KeycloakRepository").Return(&gitrepository.GitRepository{}, nil)
 	mockGitClient.On("Clone", mock.Anything).Return(nil)
-	mockExecSvc.On("ExecFromDir", mock.Anything, mock.Anything).Return(nil)
+	mockExecSvc.On("ExecReturnOutput", mock.Anything).Return(bytes.Buffer{}, bytes.Buffer{}, nil)
+
+	// Act
+	err := run.DeploySystem()
+
+	// Assert
+	assert.NoError(t, err)
+	mockExecSvc.AssertExpectations(t)
+}
+
+func TestDeploySystem_AlreadyRunning_SkipsSleep(t *testing.T) {
+	// Arrange
+	run, _, _, _, _, _ := newTestRun(action.DeploySystem)
+	mockGitClient := &testhelpers.MockGitClient{}
+	mockExecSvc := &MockExecSvc{}
+	run.Config.GitClient = mockGitClient
+	run.Config.ExecSvc = mockExecSvc
+	params.BuildImages = false
+
+	var stdout bytes.Buffer
+	stdout.WriteString("Container eureka-kafka  Running\nContainer eureka-postgres  Running\n")
+	mockGitClient.On("KongRepository").Return(&gitrepository.GitRepository{}, nil)
+	mockGitClient.On("KeycloakRepository").Return(&gitrepository.GitRepository{}, nil)
+	mockGitClient.On("Clone", mock.Anything).Return(nil)
+	mockExecSvc.On("ExecReturnOutput", mock.Anything).Return(stdout, bytes.Buffer{}, nil)
 
 	// Act
 	err := run.DeploySystem()
@@ -2328,10 +2419,89 @@ func TestDeploySystem_ExecError(t *testing.T) {
 	mockGitClient.On("KongRepository").Return(&gitrepository.GitRepository{}, nil)
 	mockGitClient.On("KeycloakRepository").Return(&gitrepository.GitRepository{}, nil)
 	mockGitClient.On("Clone", mock.Anything).Return(nil)
-	mockExecSvc.On("ExecFromDir", mock.Anything, mock.Anything).Return(expectedError)
+	mockExecSvc.On("ExecReturnOutput", mock.Anything).Return(bytes.Buffer{}, bytes.Buffer{}, expectedError)
 
 	// Act
 	err := run.DeploySystem()
+
+	// Assert
+	assert.Error(t, err)
+	assert.Equal(t, expectedError, err)
+}
+
+// ==================== DeployAdditionalSystem Tests ====================
+
+func TestDeployAdditionalSystem_NoContainers_Skips(t *testing.T) {
+	// Arrange
+	run, _, _, _, _, _ := newTestRun(action.DeployAdditionalSystem)
+	mockExecSvc := &MockExecSvc{}
+	run.Config.ExecSvc = mockExecSvc
+	// ConfigBackendModules is nil — no containers matched, returns early
+
+	// Act
+	err := run.DeployAdditionalSystem()
+
+	// Assert
+	assert.NoError(t, err)
+	mockExecSvc.AssertNotCalled(t, "ExecReturnOutput", mock.Anything)
+}
+
+func TestDeployAdditionalSystem_NewContainers_Sleeps(t *testing.T) {
+	// Arrange
+	run, _, _, _, _, _ := newTestRun(action.DeployAdditionalSystem)
+	mockExecSvc := &MockExecSvc{}
+	run.Config.ExecSvc = mockExecSvc
+	run.Config.Action.ConfigBackendModules = map[string]any{
+		constant.ModSearchModule: map[string]any{field.ModuleDeployModuleEntry: true},
+	}
+
+	var stderr bytes.Buffer
+	stderr.WriteString(" Started\n")
+	mockExecSvc.On("ExecReturnOutput", mock.Anything).Return(bytes.Buffer{}, stderr, nil)
+
+	// Act
+	err := run.DeployAdditionalSystem()
+
+	// Assert
+	assert.NoError(t, err)
+	mockExecSvc.AssertExpectations(t)
+}
+
+func TestDeployAdditionalSystem_AlreadyRunning_SkipsSleep(t *testing.T) {
+	// Arrange
+	run, _, _, _, _, _ := newTestRun(action.DeployAdditionalSystem)
+	mockExecSvc := &MockExecSvc{}
+	run.Config.ExecSvc = mockExecSvc
+	run.Config.Action.ConfigBackendModules = map[string]any{
+		constant.ModSearchModule: map[string]any{field.ModuleDeployModuleEntry: true},
+	}
+
+	var stdout bytes.Buffer
+	stdout.WriteString("Container eureka-opensearch  Running\n")
+	mockExecSvc.On("ExecReturnOutput", mock.Anything).Return(stdout, bytes.Buffer{}, nil)
+
+	// Act
+	err := run.DeployAdditionalSystem()
+
+	// Assert
+	assert.NoError(t, err)
+	mockExecSvc.AssertExpectations(t)
+}
+
+func TestDeployAdditionalSystem_ExecError(t *testing.T) {
+	// Arrange
+	run, _, _, _, _, _ := newTestRun(action.DeployAdditionalSystem)
+	mockExecSvc := &MockExecSvc{}
+	run.Config.ExecSvc = mockExecSvc
+	run.Config.Action.ConfigBackendModules = map[string]any{
+		constant.ModSearchModule: map[string]any{field.ModuleDeployModuleEntry: true},
+	}
+
+	expectedError := assert.AnError
+	mockExecSvc.On("ExecReturnOutput", mock.Anything).Return(bytes.Buffer{}, bytes.Buffer{}, expectedError)
+
+	// Act
+	err := run.DeployAdditionalSystem()
 
 	// Assert
 	assert.Error(t, err)

--- a/eureka-cli/cmd/deployAdditionalSystem.go
+++ b/eureka-cli/cmd/deployAdditionalSystem.go
@@ -17,8 +17,6 @@ package cmd
 
 import (
 	"log/slog"
-	"os/exec"
-	"time"
 
 	"github.com/folio-org/eureka-setup/eureka-cli/action"
 	"github.com/folio-org/eureka-setup/eureka-cli/constant"
@@ -49,20 +47,8 @@ func (run *Run) DeployAdditionalSystem() error {
 		return nil
 	}
 
-	homeDir, err := helpers.GetHomeMiscDir()
-	if err != nil {
-		return err
-	}
-
 	subCommand := append([]string{"compose", "--progress", "plain", "--ansi", "never", "--project-name", "eureka", "up", "--detach"}, finalRequiredContainers...)
-	if err := run.Config.ExecSvc.ExecFromDir(exec.Command("docker", subCommand...), homeDir); err != nil {
-		return err
-	}
-	slog.Info(run.Config.Action.Name, "text", "WAITING FOR ADDITIONAL SYSTEM CONTAINERS TO BECOME READY")
-	time.Sleep(constant.DeployAdditionalSystemWait)
-	slog.Info(run.Config.Action.Name, "text", "All additional system containers are ready")
-
-	return nil
+	return run.dockerComposeUp(subCommand, constant.DeployAdditionalSystemWait, "additional system")
 }
 
 func init() {

--- a/eureka-cli/cmd/deployManagement.go
+++ b/eureka-cli/cmd/deployManagement.go
@@ -65,7 +65,7 @@ func (run *Run) DeployManagement() error {
 	}
 
 	slog.Info(run.Config.Action.Name, "text", "DEPLOYING MANAGEMENT MODULES")
-	deployedModules, err := run.Config.ModuleSvc.DeployModules(client, &models.Containers{
+	newlyDeployed, totalMatched, err := run.Config.ModuleSvc.DeployModules(client, &models.Containers{
 		Modules:        modules,
 		BackendModules: backendModules,
 		IsManagement:   true,
@@ -73,19 +73,23 @@ func (run *Run) DeployManagement() error {
 	if err != nil {
 		return err
 	}
-	if len(deployedModules) == 0 {
-		return errors.ModulesNotDeployed(len(deployedModules))
+	if totalMatched == 0 {
+		return errors.ModulesNotDeployed(totalMatched)
 	}
-	time.Sleep(constant.DeployManagementWait)
+	if len(newlyDeployed) == 0 {
+		slog.Info(run.Config.Action.Name, "text", "All management modules already deployed, skipping healthchecks")
+	} else {
+		time.Sleep(constant.DeployManagementWait)
 
-	slog.Info(run.Config.Action.Name, "text", "WAITING FOR MANAGEMENT MODULES TO BECOME READY")
-	if err := run.CheckDeployedModuleReadiness(constant.Management, deployedModules); err != nil {
-		return err
-	}
+		slog.Info(run.Config.Action.Name, "text", "WAITING FOR MANAGEMENT MODULES TO BECOME READY")
+		if err := run.CheckDeployedModuleReadiness(constant.Management, newlyDeployed); err != nil {
+			return err
+		}
 
-	slog.Info(run.Config.Action.Name, "text", "WAITING FOR KONG ROUTES TO BECOME READY")
-	if err := run.Config.KongSvc.CheckRouteReadiness(); err != nil {
-		return err
+		slog.Info(run.Config.Action.Name, "text", "WAITING FOR KONG ROUTES TO BECOME READY")
+		if err := run.Config.KongSvc.CheckRouteReadiness(); err != nil {
+			return err
+		}
 	}
 
 	slog.Info(run.Config.Action.Name, "text", "UPDATING REALM SETTINGS")

--- a/eureka-cli/cmd/deployModules.go
+++ b/eureka-cli/cmd/deployModules.go
@@ -92,18 +92,22 @@ func (run *Run) DeployModules() error {
 
 	slog.Info(run.Config.Action.Name, "text", "DEPLOYING MODULES")
 	sidecarResources := helpers.CreateResources(false, run.Config.Action.ConfigSidecarModuleResources)
-	deployedModules, err := run.Config.ModuleSvc.DeployModules(client, containers, sidecarImage, sidecarResources)
+	newlyDeployed, totalMatched, err := run.Config.ModuleSvc.DeployModules(client, containers, sidecarImage, sidecarResources)
 	if err != nil {
 		return err
 	}
-	if len(deployedModules) == 0 {
-		return errors.ModulesNotDeployed(len(deployedModules))
+	if totalMatched == 0 {
+		return errors.ModulesNotDeployed(totalMatched)
 	}
-	time.Sleep(constant.DeployModulesWait)
+	if len(newlyDeployed) == 0 {
+		slog.Info(run.Config.Action.Name, "text", "All modules already deployed, skipping healthchecks")
+	} else {
+		time.Sleep(constant.DeployModulesWait)
 
-	slog.Info(run.Config.Action.Name, "text", "WAITING FOR MODULES TO BECOME READY")
-	if err := run.CheckDeployedModuleReadiness(constant.Module, deployedModules); err != nil {
-		return err
+		slog.Info(run.Config.Action.Name, "text", "WAITING FOR MODULES TO BECOME READY")
+		if err := run.CheckDeployedModuleReadiness(constant.Module, newlyDeployed); err != nil {
+			return err
+		}
 	}
 
 	slog.Info(run.Config.Action.Name, "text", "CREATING APPLICATION")

--- a/eureka-cli/cmd/deployModules.go
+++ b/eureka-cli/cmd/deployModules.go
@@ -71,7 +71,7 @@ func (run *Run) DeployModules() error {
 		return err
 	}
 
-	slog.Info(run.Config.Action.Name, "text", "PULLING SIDECAR IMAGE")
+	slog.Info(run.Config.Action.Name, "text", "PREPARING SIDECAR IMAGE")
 	containers := &models.Containers{
 		Modules:        modules,
 		BackendModules: backendModules,
@@ -82,7 +82,7 @@ func (run *Run) DeployModules() error {
 		return err
 	}
 
-	slog.Info(run.Config.Action.Name, "text", "Using sidecar image", "image", sidecarImage)
+	slog.Info(run.Config.Action.Name, "text", "Using sidecar image", "image", sidecarImage, "pullImage", pullSidecarImage)
 	if pullSidecarImage {
 		err = run.Config.ModuleSvc.PullModule(client, sidecarImage)
 		if err != nil {

--- a/eureka-cli/cmd/deploySystem.go
+++ b/eureka-cli/cmd/deploySystem.go
@@ -18,6 +18,7 @@ package cmd
 import (
 	"log/slog"
 	"os/exec"
+	"strings"
 	"time"
 
 	"github.com/folio-org/eureka-setup/eureka-cli/action"
@@ -59,16 +60,30 @@ func (run *Run) DeploySystem() error {
 	}
 
 	slog.Info(run.Config.Action.Name, "text", "DEPLOYING SYSTEM CONTAINERS")
+	return run.dockerComposeUp(subCommand, constant.DeploySystemWait, "system")
+}
+
+func (run *Run) dockerComposeUp(subCommand []string, wait time.Duration, label string) error {
 	homeDir, err := helpers.GetHomeMiscDir()
 	if err != nil {
 		return err
 	}
-	if err := run.Config.ExecSvc.ExecFromDir(exec.Command("docker", subCommand...), homeDir); err != nil {
+	dockerCmd := exec.Command("docker", subCommand...)
+	dockerCmd.Dir = homeDir
+
+	stdout, stderr, err := run.Config.ExecSvc.ExecReturnOutput(dockerCmd)
+	if err != nil {
 		return err
 	}
-	slog.Info(run.Config.Action.Name, "text", "WAITING FOR SYSTEM CONTAINERS TO BECOME READY")
-	time.Sleep(constant.DeploySystemWait)
-	slog.Info(run.Config.Action.Name, "text", "All system containers are ready")
+
+	combined := stdout.String() + stderr.String()
+	if strings.Contains(combined, " Started") || strings.Contains(combined, " Created") {
+		slog.Info(run.Config.Action.Name, "text", "WAITING FOR "+strings.ToUpper(label)+" CONTAINERS TO BECOME READY")
+		time.Sleep(wait)
+		slog.Info(run.Config.Action.Name, "text", "All "+label+" containers are ready")
+	} else {
+		slog.Info(run.Config.Action.Name, "text", "All "+label+" containers already running, skipping wait")
+	}
 
 	return nil
 }

--- a/eureka-cli/cmd/deploySystem.go
+++ b/eureka-cli/cmd/deploySystem.go
@@ -16,6 +16,7 @@ limitations under the License.
 package cmd
 
 import (
+	"fmt"
 	"log/slog"
 	"os/exec"
 	"strings"
@@ -43,6 +44,7 @@ var deploySystemCmd = &cobra.Command{
 }
 
 func (run *Run) DeploySystem() error {
+	slog.Info(run.Config.Action.Name, "text", "DEPLOYING SYSTEM CONTAINERS")
 	if err := run.CloneUpdateRepositories(); err != nil {
 		return err
 	}
@@ -59,7 +61,6 @@ func (run *Run) DeploySystem() error {
 		subCommand = append(subCommand, finalRequiredContainers...)
 	}
 
-	slog.Info(run.Config.Action.Name, "text", "DEPLOYING SYSTEM CONTAINERS")
 	return run.dockerComposeUp(subCommand, constant.DeploySystemWait, "system")
 }
 
@@ -80,9 +81,9 @@ func (run *Run) dockerComposeUp(subCommand []string, wait time.Duration, label s
 	if strings.Contains(combined, " Started") || strings.Contains(combined, " Created") {
 		slog.Info(run.Config.Action.Name, "text", "WAITING FOR "+strings.ToUpper(label)+" CONTAINERS TO BECOME READY")
 		time.Sleep(wait)
-		slog.Info(run.Config.Action.Name, "text", "All "+label+" containers are ready")
+		slog.Info(run.Config.Action.Name, "text", fmt.Sprintf("All %s containers are ready", label))
 	} else {
-		slog.Info(run.Config.Action.Name, "text", "All "+label+" containers already running, skipping wait")
+		slog.Info(run.Config.Action.Name, "text", fmt.Sprintf("All %s containers already running, skipping wait", label))
 	}
 
 	return nil

--- a/eureka-cli/internal/testhelpers/README.md
+++ b/eureka-cli/internal/testhelpers/README.md
@@ -1,202 +1,44 @@
 # Internal Test Helpers Package
 
-## Overview
+Reusable testing utilities for eureka-cli. Import path: `github.com/folio-org/eureka-setup/eureka-cli/internal/testhelpers`
 
-This package provides reusable testing utilities for the eureka-cli project, enabling consistent, maintainable, and efficient unit and integration tests.
+## Files
 
-## Package Contents
+| File                | Contents                                                              |
+|:--------------------|:----------------------------------------------------------------------|
+| `mocks.go`          | `NewMockAction()`, `MockHTTPClient`, `MockCommandExecutor`, `MockRegistrySvc`, `MockModuleEnv`, `MockDockerClient`, `MockTenantSvc` |
+| `git_mocks.go`      | `MockGitClient` — mock for `gitclient.GitClientRunner` (`KongRepository`, `KeycloakRepository`, `PlatformCompleteRepository`, `Clone`, `ResetHardPullFromOrigin`) |
+| `http_helpers.go`   | `MockHTTPServer`, `JSONResponse`, `ErrorResponse`, `EmptyResponse`, `SequentialResponses`, request assertion helpers |
+| `file_helpers.go`   | `CreateTempJSONFile`, `CreateTempFile`, `CreateJSONFileInDir`, `CreateFileInDir`, `ReadFileContent` |
+| `viper_helpers.go`  | `ViperTestConfig` — tracks original values and restores them in `Reset()`; `SetupViperForTest(map[string]any)` for bulk setup |
+| `doc.go`            | Package doc comment                                                   |
 
-### 1. `http_helpers.go`
+## Key mocks
 
-HTTP testing utilities for mocking HTTP servers and responses:
+**`NewMockAction()`** — returns `*action.Action` with name `"test-action"` and empty `Param`. Set fields directly after construction (e.g. `action.ConfigProfileName = "platform-complete"`).
 
-- **MockHTTPServer**: Test HTTP server with request capture and assertion helpers
-- **JSONResponse**: Handler for JSON responses
-- **ErrorResponse**: Handler for error responses  
-- **EmptyResponse**: Handler for empty responses
-- **SequentialResponses**: Handler for sequential different responses
-- **Assertion helpers**: Request count, method, path, headers, body validation
+**`MockCommandExecutor`** — implements `execsvc.CommandRunner`: `Exec`, `ExecReturnOutput`, `ExecFromDir`. Also has `ExecIgnoreError` as an extra method not present in the interface — do not stub it unless the code under test calls it directly. When mocking `ExecReturnOutput`, always return `(bytes.Buffer, bytes.Buffer, error)`.
 
-### 2. `mocks.go`
+> **Note:** `cmd/cmd_test.go` defines its own `MockExecSvc` (three interface methods only) for use within `cmd/` tests. Do not replace it with `MockCommandExecutor` — they are separate types serving different test scopes.
 
-Mock implementations of key interfaces:
+**`MockHTTPClient`** — implements all `httpclient.HTTPClientRunner` methods. Use `.On("MethodName", mock.Anything, ...).Return(...)`.
 
-- **MockHTTPClient**: Mock for `httpclient.HTTPClientRunner` interface
-- **NewMockAction()**: Returns a real `*action.Action` with an empty `Param` — set fields directly
-- **MockCommandExecutor**: Mock for `execsvc.CommandRunner` interface
-- **MockRegistrySvc**: Mock for `registrysvc.RegistryProcessor` interface — `GetModules(verbose, forceRefresh bool)`
-- **MockModuleEnv**: Mock for `moduleenv.ModuleEnvProcessor` interface
-- **MockDockerClient**: Mock for `dockerclient.DockerClientRunner` interface
-- **MockTenantSvc**: Mock for `tenantsvc.TenantProcessor` interface
-- Additional mocks can be added as needed
+**`MockRegistrySvc`** — `GetModules(verbose, forceRefresh bool)` — both args required in every `.On()` call. `forceRefresh=true` exercises network path; `false` exercises local file path.
 
-### 3. `doc.go`
+**`MockDockerClient`** — implements `dockerclient.DockerClientRunner`: `Create`, `Close`, `PushImage`, `ForcePullImage`.
 
-Package documentation
-
-### 4. `TESTING_GUIDE.md`
-
-Comprehensive testing system prompt containing:
-
-- Testing principles and patterns
-- Test organization guidelines
-- HTTP testing patterns (mock server vs mock client)
-- Table-driven test examples
-- Error scenario testing
-- Service-specific testing strategies
-- Test maintenance and coverage guidelines
-- Token-efficient testing approach
-
-## Quick Start
-
-### Install Dependencies
+## Running tests
 
 ```bash
-go get github.com/stretchr/testify
-```
-
-### Example: Testing with Mock HTTP Server
-
-```go
-package httpclient_test
-
-import (
-  "testing"
-  "net/http"
-  
-  "github.com/folio-org/eureka-setup/eureka-cli/internal/testhelpers"
-  "github.com/stretchr/testify/assert"
-)
-
-func TestHTTPClient_GetRequest(t *testing.T) {
-  // Create mock server
-  mockServer := testhelpers.NewMockHTTPServer(t, 
-    testhelpers.JSONResponse(http.StatusOK, map[string]string{"status": "ok"}))
-  defer mockServer.Close()
-  
-  // Test code here...
-  
-  // Assertions
-  mockServer.AssertRequestCount(1)
-  mockServer.AssertRequestMethod(0, "GET")
-}
-```
-
-### Example: Testing with Mock HTTP Client
-
-```go
-package searchsvc_test
-
-import (
-  "testing"
-  
-  "github.com/folio-org/eureka-setup/eureka-cli/internal/testhelpers"
-  "github.com/folio-org/eureka-setup/eureka-cli/searchsvc"
-  "github.com/stretchr/testify/assert"
-  "github.com/stretchr/testify/mock"
-)
-
-func TestSearchSvc_ReindexInventoryRecords(t *testing.T) {
-  // Setup mocks
-  mockHTTP := &testhelpers.MockHTTPClient{}
-  action := testhelpers.NewMockAction()
-  svc := searchsvc.New(action, mockHTTP)
-  
-  // Configure expectations
-  mockHTTP.On("PostReturnStruct", 
-    mock.Anything, 
-    mock.Anything, 
-    mock.Anything, 
-    mock.Anything).Return(nil)
-  
-  // Test code here...
-  
-  // Verify expectations
-  mockHTTP.AssertExpectations(t)
-}
-```
-
-## Testing Strategy
-
-### Phase 1: Core Utilities (High Priority)
-
-- HTTP client methods
-- Error package functions
-- Helper utilities
-
-### Phase 2: Service Layer (Medium Priority)
-
-- SearchSvc - reindexing operations
-- KeycloakSvc - authentication and user management
-- ManagementSvc - tenant and application operations
-- RegistrySvc - module registry operations
-- ModuleSvc - module provisioning and image management
-- TenantSvc - tenant parameters and configuration
-
-### Phase 3: Integration Tests (Low Priority)
-
-- End-to-end flows
-- Multi-service interactions
-
-## Best Practices
-
-✅ **DO**:
-
-- Use table-driven tests for multiple scenarios
-- Mock all external dependencies
-- Test both success and error paths
-- Keep tests independent
-- Use descriptive test names
-- Test edge cases with empty strings and special characters
-- Verify URL parameter formatting and escaping
-- Use `_ = os.Remove(...)` / `_ = os.Rename(...)` in `t.Cleanup` closures to satisfy errcheck
-- Run `golangci-lint run ./...` once as the final finishing move
-- Target specific packages with `go test ./pkg/...` rather than `go test ./...`
-
-❌ **DON'T**:
-
-- Test external services directly
-- Share state between tests
-- Use time.Sleep()
-- Ignore test setup errors
-- Write flaky tests
-- Leave duplicate test function names
-- Forget to test error paths (headers, HTTP errors)
-- Run `go test ./...` across the whole module (RAM constrained)
-
-## Running Tests
-
-```bash
-# Run specific package (preferred — machine is RAM-constrained)
-go test ./registrysvc/...
+# Target a single package — machine is RAM-constrained
 go test ./cmd/...
+go test ./modulesvc/...
 
-# Run with race detection on a single package
-go test -race ./registrysvc/...
+# Docker API tests use httptest, no real daemon needed:
+# client.NewClientWithOpts(client.WithHost(ts.URL), client.WithVersion("1.41"))
 
-# Lint — run once as a finishing move
+# Lint once as finishing move
 golangci-lint run ./...
-
-# Coverage for a single package
-go test -coverprofile=coverage.out ./registrysvc/...
-go tool cover -html=coverage.out
 ```
 
-> **Note**: Avoid `go test ./...` across the full module — it consumes significant RAM.
-
-## Contributing
-
-When adding new test helpers:
-
-1. Add to appropriate file (`http_helpers.go` or `mocks.go`)
-2. Document with clear comments
-3. Add usage examples to TESTING_GUIDE.md
-4. Ensure helpers are reusable across packages
-5. Keep helpers simple and focused
-
-## References
-
-- [TESTING_GUIDE.md](./TESTING_GUIDE.md) - Comprehensive testing system prompt
-- [Go Testing Package](https://pkg.go.dev/testing)
-- [Testify](https://github.com/stretchr/testify)
-- [Go Testing Best Practices](https://go.dev/doc/tutorial/add-a-test)
+See [TESTING_GUIDE.md](./TESTING_GUIDE.md) for AAA structure, HTTP patterns, table-driven tests, and service-specific notes.

--- a/eureka-cli/keycloaksvc/keycloak_svc_capability_set.go
+++ b/eureka-cli/keycloaksvc/keycloak_svc_capability_set.go
@@ -18,6 +18,7 @@ import (
 type KeycloakCapabilitySetManager interface {
 	GetCapabilitySets(headers map[string]string) ([]any, error)
 	GetCapabilitySetsByName(headers map[string]string, capabilityName string) ([]any, error)
+	HasCapabilitySets(tenantName string) (bool, error)
 	AttachCapabilitySetsToRoles(tenantName string) error
 	DetachCapabilitySetsFromRoles(tenantName string) error
 }
@@ -81,6 +82,18 @@ func (ks *KeycloakSvc) GetCapabilitySetsByName(headers map[string]string, capabi
 	return result, nil
 }
 
+func (ks *KeycloakSvc) HasCapabilitySets(tenantName string) (bool, error) {
+	headers, err := helpers.SecureOkapiTenantApplicationJSONHeaders(tenantName, ks.Action.KeycloakAccessToken)
+	if err != nil {
+		return false, err
+	}
+	sets, err := ks.GetCapabilitySets(headers)
+	if err != nil {
+		return false, err
+	}
+	return len(sets) > 0, nil
+}
+
 func (ks *KeycloakSvc) AttachCapabilitySetsToRoles(tenantName string) error {
 	headers, err := helpers.SecureOkapiTenantApplicationJSONHeaders(tenantName, ks.Action.KeycloakAccessToken)
 	if err != nil {
@@ -116,6 +129,28 @@ func (ks *KeycloakSvc) AttachCapabilitySetsToRoles(tenantName string) error {
 		}
 		if len(capabilitySets) == 0 {
 			slog.Warn(ks.Action.Name, "text", "No capability sets were attached", "role", roleName, "tenant", tenantName)
+			continue
+		}
+
+		alreadyAttached, err := ks.getRoleCapabilitySetIDs(helpers.GetString(entry, "id"), headers)
+		if err != nil {
+			return err
+		}
+		if len(alreadyAttached) > 0 {
+			attachedSet := make(map[string]struct{}, len(alreadyAttached))
+			for _, id := range alreadyAttached {
+				attachedSet[id] = struct{}{}
+			}
+			var delta []string
+			for _, id := range capabilitySets {
+				if _, exists := attachedSet[id]; !exists {
+					delta = append(delta, id)
+				}
+			}
+			capabilitySets = delta
+		}
+		if len(capabilitySets) == 0 {
+			slog.Info(ks.Action.Name, "text", "All capability sets already attached, skipping", "role", roleName, "tenant", tenantName)
 			continue
 		}
 
@@ -173,6 +208,25 @@ func (ks *KeycloakSvc) populateCapabilitySets(headers map[string]string, rolesCa
 	}
 
 	return capabilitySets, nil
+}
+
+func (ks *KeycloakSvc) getRoleCapabilitySetIDs(roleID string, headers map[string]string) ([]string, error) {
+	requestURL := ks.Action.GetRequestURL(constant.KongPort, fmt.Sprintf("/roles/%s/capability-sets?limit=10000", roleID))
+
+	var decodedResponse models.KeycloakCapabilitySetsResponse
+	if err := ks.HTTPClient.GetRetryReturnStruct(requestURL, headers, &decodedResponse); err != nil {
+		if errors.Is(err, apperrors.ErrHTTP404NotFound) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	ids := make([]string, 0, len(decodedResponse.CapabilitySets))
+	for _, cs := range decodedResponse.CapabilitySets {
+		ids = append(ids, cs.ID)
+	}
+
+	return ids, nil
 }
 
 func (ks *KeycloakSvc) DetachCapabilitySetsFromRoles(tenantName string) error {

--- a/eureka-cli/keycloaksvc/keycloak_svc_role.go
+++ b/eureka-cli/keycloaksvc/keycloak_svc_role.go
@@ -80,6 +80,15 @@ func (ks *KeycloakSvc) CreateRoles(configTenant string) error {
 			return err
 		}
 
+		existingRole, err := ks.GetRoleByName(ks.Action.Caser.String(role), headers)
+		if err != nil {
+			return err
+		}
+		if existingRole != nil {
+			slog.Info(ks.Action.Name, "text", "Role already exists, skipping", "role", role, "tenant", tenantName)
+			continue
+		}
+
 		payload, err := json.Marshal(map[string]string{
 			"name":        ks.Action.Caser.String(role),
 			"description": "Default",

--- a/eureka-cli/keycloaksvc/keycloak_svc_test.go
+++ b/eureka-cli/keycloaksvc/keycloak_svc_test.go
@@ -1036,6 +1036,14 @@ func TestCreateRoles_Success(t *testing.T) {
 	mockMgmt := &MockManagementSvc{}
 	svc := keycloaksvc.New(action, mockHTTP, mockVault, mockMgmt)
 
+	mockHTTP.On("GetRetryReturnStruct",
+		mock.MatchedBy(func(urlStr string) bool {
+			return strings.Contains(urlStr, "/roles?query=name==")
+		}),
+		mock.Anything,
+		mock.Anything).
+		Return(nil)
+
 	mockHTTP.On("PostReturnNoContent",
 		mock.MatchedBy(func(urlStr string) bool {
 			return strings.Contains(urlStr, "/roles")
@@ -1090,6 +1098,14 @@ func TestCreateRoles_HTTPError(t *testing.T) {
 	mockVault := &MockVaultClient{}
 	mockMgmt := &MockManagementSvc{}
 	svc := keycloaksvc.New(action, mockHTTP, mockVault, mockMgmt)
+
+	mockHTTP.On("GetRetryReturnStruct",
+		mock.MatchedBy(func(urlStr string) bool {
+			return strings.Contains(urlStr, "/roles?query=name==")
+		}),
+		mock.Anything,
+		mock.Anything).
+		Return(nil)
 
 	expectedError := errors.New("HTTP POST failed")
 	mockHTTP.On("PostReturnNoContent",
@@ -1343,6 +1359,14 @@ func TestCreateUsers_Success(t *testing.T) {
 	svc := keycloaksvc.New(action, mockHTTP, mockVault, mockMgmt)
 
 	createdUser := map[string]any{"id": "user-123"}
+
+	mockHTTP.On("GetRetryReturnStruct",
+		mock.MatchedBy(func(urlStr string) bool {
+			return strings.Contains(urlStr, "/users?query=username==")
+		}),
+		mock.Anything,
+		mock.Anything).
+		Return(nil)
 
 	mockHTTP.On("PostReturnStruct",
 		mock.MatchedBy(func(urlStr string) bool {
@@ -1669,6 +1693,91 @@ func TestGetCapabilitySets_GetApplicationsError(t *testing.T) {
 	mockMgmt.AssertExpectations(t)
 }
 
+func TestHasCapabilitySets_ReturnsFalse_WhenEmpty(t *testing.T) {
+	// Arrange
+	mockHTTP := &testhelpers.MockHTTPClient{}
+	act := testhelpers.NewMockAction()
+	act.KeycloakAccessToken = "token"
+	mockVault := &MockVaultClient{}
+	mockMgmt := &MockManagementSvc{}
+	svc := keycloaksvc.New(act, mockHTTP, mockVault, mockMgmt)
+
+	mockMgmt.On("GetApplications").Return(models.ApplicationsResponse{ApplicationDescriptors: []map[string]any{{"id": "app-1"}}}, nil)
+	mockHTTP.On("GetRetryReturnStruct", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+
+	// Act
+	has, err := svc.HasCapabilitySets("test-tenant")
+
+	// Assert
+	assert.NoError(t, err)
+	assert.False(t, has)
+}
+
+func TestHasCapabilitySets_ReturnsTrue_WhenNonEmpty(t *testing.T) {
+	// Arrange
+	mockHTTP := &testhelpers.MockHTTPClient{}
+	act := testhelpers.NewMockAction()
+	act.KeycloakAccessToken = "token"
+	mockVault := &MockVaultClient{}
+	mockMgmt := &MockManagementSvc{}
+	svc := keycloaksvc.New(act, mockHTTP, mockVault, mockMgmt)
+
+	capSetsResponse := models.KeycloakCapabilitySetsResponse{
+		CapabilitySets: []models.KeycloakCapabilitySet{{ID: "cap-1", Name: "users.read", ApplicationID: "app-1"}},
+	}
+	mockMgmt.On("GetApplications").Return(models.ApplicationsResponse{ApplicationDescriptors: []map[string]any{{"id": "app-1"}}}, nil)
+	mockHTTP.On("GetRetryReturnStruct", mock.Anything, mock.Anything, mock.Anything).
+		Run(func(args mock.Arguments) {
+			*args.Get(2).(*models.KeycloakCapabilitySetsResponse) = capSetsResponse
+		}).
+		Return(nil)
+
+	// Act
+	has, err := svc.HasCapabilitySets("test-tenant")
+
+	// Assert
+	assert.NoError(t, err)
+	assert.True(t, has)
+}
+
+func TestHasCapabilitySets_HeadersError(t *testing.T) {
+	// Arrange
+	mockHTTP := &testhelpers.MockHTTPClient{}
+	act := testhelpers.NewMockAction()
+	// KeycloakAccessToken left empty — SecureOkapiTenantApplicationJSONHeaders returns error
+	mockVault := &MockVaultClient{}
+	mockMgmt := &MockManagementSvc{}
+	svc := keycloaksvc.New(act, mockHTTP, mockVault, mockMgmt)
+
+	// Act
+	has, err := svc.HasCapabilitySets("test-tenant")
+
+	// Assert
+	assert.Error(t, err)
+	assert.False(t, has)
+}
+
+func TestHasCapabilitySets_GetCapabilitySetsError(t *testing.T) {
+	// Arrange
+	mockHTTP := &testhelpers.MockHTTPClient{}
+	act := testhelpers.NewMockAction()
+	act.KeycloakAccessToken = "token"
+	mockVault := &MockVaultClient{}
+	mockMgmt := &MockManagementSvc{}
+	svc := keycloaksvc.New(act, mockHTTP, mockVault, mockMgmt)
+
+	expectedError := errors.New("get applications failed")
+	mockMgmt.On("GetApplications").Return(models.ApplicationsResponse{}, expectedError)
+
+	// Act
+	has, err := svc.HasCapabilitySets("test-tenant")
+
+	// Assert
+	assert.Error(t, err)
+	assert.Equal(t, expectedError, err)
+	assert.False(t, has)
+}
+
 func TestGetCapabilitySetsByName_Success(t *testing.T) {
 	// Arrange
 	mockHTTP := &testhelpers.MockHTTPClient{}
@@ -1786,6 +1895,14 @@ func TestAttachCapabilitySetsToRoles_Success(t *testing.T) {
 			target := args.Get(2).(*models.KeycloakCapabilitySetsResponse)
 			*target = capSetsResponse
 		}).
+		Return(nil)
+
+	mockHTTP.On("GetRetryReturnStruct",
+		mock.MatchedBy(func(urlStr string) bool {
+			return strings.Contains(urlStr, "/capability-sets?limit=10000")
+		}),
+		mock.Anything,
+		mock.Anything).
 		Return(nil)
 
 	mockHTTP.On("PostRetryReturnNoContent",
@@ -2189,6 +2306,14 @@ func TestAttachCapabilitySetsToRoles_WithAllCapabilitySets(t *testing.T) {
 		}).
 		Return(nil)
 
+	mockHTTP.On("GetRetryReturnStruct",
+		mock.MatchedBy(func(urlStr string) bool {
+			return strings.Contains(urlStr, "/capability-sets?limit=10000")
+		}),
+		mock.Anything,
+		mock.Anything).
+		Return(nil)
+
 	mockHTTP.On("PostRetryReturnNoContent",
 		mock.MatchedBy(func(urlStr string) bool {
 			return strings.Contains(urlStr, "/roles/capability-sets")
@@ -2270,6 +2395,14 @@ func TestAttachCapabilitySetsToRoles_LargeBatchSplitting(t *testing.T) {
 		Return(nil)
 
 	// Expect 2 batches: 250 + 50
+	mockHTTP.On("GetRetryReturnStruct",
+		mock.MatchedBy(func(urlStr string) bool {
+			return strings.Contains(urlStr, "/capability-sets?limit=10000")
+		}),
+		mock.Anything,
+		mock.Anything).
+		Return(nil)
+
 	mockHTTP.On("PostRetryReturnNoContent",
 		mock.MatchedBy(func(urlStr string) bool {
 			return strings.Contains(urlStr, "/roles/capability-sets")
@@ -2524,6 +2657,14 @@ func TestAttachCapabilitySetsToRoles_PostError(t *testing.T) {
 		}).
 		Return(nil)
 
+	mockHTTP.On("GetRetryReturnStruct",
+		mock.MatchedBy(func(urlStr string) bool {
+			return strings.Contains(urlStr, "/capability-sets?limit=10000")
+		}),
+		mock.Anything,
+		mock.Anything).
+		Return(nil)
+
 	mockHTTP.On("PostRetryReturnNoContent",
 		mock.Anything,
 		mock.Anything,
@@ -2536,5 +2677,231 @@ func TestAttachCapabilitySetsToRoles_PostError(t *testing.T) {
 	// Assert
 	assert.Error(t, err)
 	assert.Equal(t, expectedError, err)
+	mockHTTP.AssertExpectations(t)
+}
+
+// ==================== Idempotency Tests ====================
+
+func TestCreateRoles_RoleAlreadyExists_Skipped(t *testing.T) {
+	// Arrange
+	mockHTTP := &testhelpers.MockHTTPClient{}
+	action := testhelpers.NewMockAction()
+	action.KeycloakAccessToken = "test-token"
+	action.ConfigRoles = map[string]any{
+		"admin": map[string]any{
+			"tenant": "test-tenant",
+		},
+	}
+	mockVault := &MockVaultClient{}
+	mockMgmt := &MockManagementSvc{}
+	svc := keycloaksvc.New(action, mockHTTP, mockVault, mockMgmt)
+
+	mockHTTP.On("GetRetryReturnStruct",
+		mock.MatchedBy(func(urlStr string) bool {
+			return strings.Contains(urlStr, "/roles?query=name==")
+		}),
+		mock.Anything,
+		mock.Anything).
+		Run(func(args mock.Arguments) {
+			target := args.Get(2).(*models.KeycloakRolesResponse)
+			target.Roles = []models.KeycloakRole{{ID: "role-1", Name: "admin"}}
+			target.TotalCount = 1
+		}).
+		Return(nil)
+
+	// Act
+	err := svc.CreateRoles("test-tenant")
+
+	// Assert
+	assert.NoError(t, err)
+	mockHTTP.AssertNotCalled(t, "PostReturnNoContent", mock.Anything, mock.Anything, mock.Anything)
+}
+
+func TestCreateUsers_UserAlreadyExists_Skipped(t *testing.T) {
+	// Arrange
+	mockHTTP := &testhelpers.MockHTTPClient{}
+	action := testhelpers.NewMockAction()
+	action.KeycloakAccessToken = "test-token"
+	action.ConfigUsers = map[string]any{
+		"testuser": map[string]any{
+			"tenant":     "test-tenant",
+			"password":   "pass123",
+			"first-name": "Test",
+			"last-name":  "User",
+		},
+	}
+	mockVault := &MockVaultClient{}
+	mockMgmt := &MockManagementSvc{}
+	svc := keycloaksvc.New(action, mockHTTP, mockVault, mockMgmt)
+
+	mockHTTP.On("GetRetryReturnStruct",
+		mock.MatchedBy(func(urlStr string) bool {
+			return strings.Contains(urlStr, "/users?query=username==")
+		}),
+		mock.Anything,
+		mock.Anything).
+		Run(func(args mock.Arguments) {
+			target := args.Get(2).(*models.KeycloakUsersResponse)
+			target.Users = []models.KeycloakUser{{ID: "user-1", Username: "testuser", Active: true}}
+		}).
+		Return(nil)
+
+	// Act
+	err := svc.CreateUsers("test-tenant")
+
+	// Assert
+	assert.NoError(t, err)
+	mockHTTP.AssertNotCalled(t, "PostReturnStruct", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+	mockHTTP.AssertNotCalled(t, "PostReturnNoContent", mock.Anything, mock.Anything, mock.Anything)
+}
+
+func TestAttachCapabilitySetsToRoles_AllAlreadyAttached_Skipped(t *testing.T) {
+	// Arrange
+	mockHTTP := &testhelpers.MockHTTPClient{}
+	action := testhelpers.NewMockAction()
+	action.KeycloakAccessToken = "test-token"
+	action.ConfigRoles = map[string]any{
+		"admin": map[string]any{
+			"tenant":          "test-tenant",
+			"capability-sets": []any{"users.read"},
+		},
+	}
+	mockVault := &MockVaultClient{}
+	mockMgmt := &MockManagementSvc{}
+	svc := keycloaksvc.New(action, mockHTTP, mockVault, mockMgmt)
+
+	rolesResponse := models.KeycloakRolesResponse{
+		Roles: []models.KeycloakRole{{ID: "role-1", Name: "admin"}},
+	}
+	capSetsResponse := models.KeycloakCapabilitySetsResponse{
+		CapabilitySets: []models.KeycloakCapabilitySet{{ID: "cap-1", Name: "users.read"}},
+	}
+
+	mockHTTP.On("GetRetryReturnStruct",
+		mock.MatchedBy(func(urlStr string) bool {
+			return strings.Contains(urlStr, "/roles?offset=0&limit=10000")
+		}),
+		mock.Anything,
+		mock.Anything).
+		Run(func(args mock.Arguments) {
+			target := args.Get(2).(*models.KeycloakRolesResponse)
+			*target = rolesResponse
+		}).
+		Return(nil)
+
+	mockHTTP.On("GetRetryReturnStruct",
+		mock.MatchedBy(func(urlStr string) bool {
+			return strings.Contains(urlStr, "/capability-sets?query=name==users.read")
+		}),
+		mock.Anything,
+		mock.Anything).
+		Run(func(args mock.Arguments) {
+			target := args.Get(2).(*models.KeycloakCapabilitySetsResponse)
+			*target = capSetsResponse
+		}).
+		Return(nil)
+
+	// cap-1 already attached — delta is empty
+	mockHTTP.On("GetRetryReturnStruct",
+		mock.MatchedBy(func(urlStr string) bool {
+			return strings.Contains(urlStr, "/capability-sets?limit=10000")
+		}),
+		mock.Anything,
+		mock.Anything).
+		Run(func(args mock.Arguments) {
+			target := args.Get(2).(*models.KeycloakCapabilitySetsResponse)
+			target.CapabilitySets = []models.KeycloakCapabilitySet{{ID: "cap-1"}}
+		}).
+		Return(nil)
+
+	// Act
+	err := svc.AttachCapabilitySetsToRoles("test-tenant")
+
+	// Assert
+	assert.NoError(t, err)
+	mockHTTP.AssertNotCalled(t, "PostRetryReturnNoContent", mock.Anything, mock.Anything, mock.Anything)
+}
+
+func TestAttachCapabilitySetsToRoles_PartiallyAttached_PostsDelta(t *testing.T) {
+	// Arrange
+	mockHTTP := &testhelpers.MockHTTPClient{}
+	action := testhelpers.NewMockAction()
+	action.KeycloakAccessToken = "test-token"
+	action.ConfigRoles = map[string]any{
+		"admin": map[string]any{
+			"tenant":          "test-tenant",
+			"capability-sets": []any{"users.read"},
+		},
+	}
+	mockVault := &MockVaultClient{}
+	mockMgmt := &MockManagementSvc{}
+	svc := keycloaksvc.New(action, mockHTTP, mockVault, mockMgmt)
+
+	rolesResponse := models.KeycloakRolesResponse{
+		Roles: []models.KeycloakRole{{ID: "role-1", Name: "admin"}},
+	}
+	// GetCapabilitySetsByName returns two entries for the single set name
+	capSetsResponse := models.KeycloakCapabilitySetsResponse{
+		CapabilitySets: []models.KeycloakCapabilitySet{
+			{ID: "cap-1", Name: "users.read"},
+			{ID: "cap-2", Name: "users.write"},
+		},
+	}
+
+	mockHTTP.On("GetRetryReturnStruct",
+		mock.MatchedBy(func(urlStr string) bool {
+			return strings.Contains(urlStr, "/roles?offset=0&limit=10000")
+		}),
+		mock.Anything,
+		mock.Anything).
+		Run(func(args mock.Arguments) {
+			target := args.Get(2).(*models.KeycloakRolesResponse)
+			*target = rolesResponse
+		}).
+		Return(nil)
+
+	mockHTTP.On("GetRetryReturnStruct",
+		mock.MatchedBy(func(urlStr string) bool {
+			return strings.Contains(urlStr, "/capability-sets?query=name==users.read")
+		}),
+		mock.Anything,
+		mock.Anything).
+		Run(func(args mock.Arguments) {
+			target := args.Get(2).(*models.KeycloakCapabilitySetsResponse)
+			*target = capSetsResponse
+		}).
+		Return(nil)
+
+	// Only cap-1 already attached; cap-2 is the delta
+	mockHTTP.On("GetRetryReturnStruct",
+		mock.MatchedBy(func(urlStr string) bool {
+			return strings.Contains(urlStr, "/capability-sets?limit=10000")
+		}),
+		mock.Anything,
+		mock.Anything).
+		Run(func(args mock.Arguments) {
+			target := args.Get(2).(*models.KeycloakCapabilitySetsResponse)
+			target.CapabilitySets = []models.KeycloakCapabilitySet{{ID: "cap-1"}}
+		}).
+		Return(nil)
+
+	mockHTTP.On("PostRetryReturnNoContent",
+		mock.MatchedBy(func(urlStr string) bool {
+			return strings.Contains(urlStr, "/roles/capability-sets")
+		}),
+		mock.MatchedBy(func(payload []byte) bool {
+			var data map[string]any
+			_ = json.Unmarshal(payload, &data)
+			ids, ok := data["capabilitySetIds"].([]any)
+			return ok && len(ids) == 1 && ids[0] == "cap-2"
+		}),
+		mock.Anything).
+		Return(nil)
+
+	// Act
+	err := svc.AttachCapabilitySetsToRoles("test-tenant")
+
+	// Assert
+	assert.NoError(t, err)
 	mockHTTP.AssertExpectations(t)
 }

--- a/eureka-cli/keycloaksvc/keycloak_svc_user.go
+++ b/eureka-cli/keycloaksvc/keycloak_svc_user.go
@@ -57,6 +57,15 @@ func (ks *KeycloakSvc) CreateUsers(configTenant string) error {
 			continue
 		}
 
+		existingUser, err := ks.getUserByUsername(tenantName, username)
+		if err != nil {
+			return err
+		}
+		if existingUser != nil {
+			slog.Info(ks.Action.Name, "text", "User already exists, skipping", "username", username, "tenant", tenantName)
+			continue
+		}
+
 		createdUser, err := ks.createUser(tenantName, username, entry)
 		if err != nil {
 			return err
@@ -76,6 +85,27 @@ func (ks *KeycloakSvc) CreateUsers(configTenant string) error {
 	}
 
 	return nil
+}
+
+func (ks *KeycloakSvc) getUserByUsername(tenantName, username string) (map[string]any, error) {
+	requestURL := ks.Action.GetRequestURL(constant.KongPort, fmt.Sprintf("/users?query=username==%s&limit=1", username))
+	headers, err := helpers.SecureOkapiTenantApplicationJSONHeaders(tenantName, ks.Action.KeycloakAccessToken)
+	if err != nil {
+		return nil, err
+	}
+
+	var decodedResponse models.KeycloakUsersResponse
+	if err := ks.HTTPClient.GetRetryReturnStruct(requestURL, headers, &decodedResponse); err != nil {
+		return nil, err
+	}
+	if len(decodedResponse.Users) == 0 {
+		return nil, nil
+	}
+
+	return map[string]any{
+		"id":       decodedResponse.Users[0].ID,
+		"username": decodedResponse.Users[0].Username,
+	}, nil
 }
 
 func (ks *KeycloakSvc) createUser(tenantName string, username string, entry map[string]any) (map[string]any, error) {

--- a/eureka-cli/managementsvc/management_svc_application.go
+++ b/eureka-cli/managementsvc/management_svc_application.go
@@ -2,6 +2,7 @@ package managementsvc
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/url"
@@ -10,7 +11,7 @@ import (
 
 	"github.com/folio-org/eureka-setup/eureka-cli/action"
 	"github.com/folio-org/eureka-setup/eureka-cli/constant"
-	"github.com/folio-org/eureka-setup/eureka-cli/errors"
+	apperrors "github.com/folio-org/eureka-setup/eureka-cli/errors"
 	"github.com/folio-org/eureka-setup/eureka-cli/helpers"
 	"github.com/folio-org/eureka-setup/eureka-cli/httpclient"
 	"github.com/folio-org/eureka-setup/eureka-cli/models"
@@ -76,13 +77,40 @@ func (ms *ManagementSvc) GetLatestApplication() (map[string]any, error) {
 		return nil, err
 	}
 	if len(decodedResponse.ApplicationDescriptors) == 0 {
-		return nil, errors.ApplicationNotFound(ms.Action.ConfigApplicationName)
+		return nil, apperrors.ApplicationNotFound(ms.Action.ConfigApplicationName)
 	}
 
 	return decodedResponse.ApplicationDescriptors[0], nil
 }
 
+func (ms *ManagementSvc) getApplicationByID(id string) (map[string]any, error) {
+	requestURL := ms.Action.GetRequestURL(constant.KongPort, fmt.Sprintf("/applications/%s", id))
+	headers, err := helpers.SecureApplicationJSONHeaders(ms.Action.KeycloakMasterAccessToken)
+	if err != nil {
+		return nil, err
+	}
+
+	var decodedResponse map[string]any
+	if err := ms.HTTPClient.GetRetryReturnStruct(requestURL, headers, &decodedResponse); err != nil {
+		if errors.Is(err, apperrors.ErrHTTP404NotFound) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	return decodedResponse, nil
+}
+
 func (ms *ManagementSvc) CreateApplication(extract *models.RegistryExtract) error {
+	existing, err := ms.getApplicationByID(ms.Action.ConfigApplicationID)
+	if err != nil {
+		return err
+	}
+	if existing != nil {
+		slog.Info(ms.Action.Name, "text", "Application already exists, skipping", "id", ms.Action.ConfigApplicationID)
+		return nil
+	}
+
 	var (
 		backendModules            []map[string]string
 		frontendModules           []map[string]string

--- a/eureka-cli/managementsvc/management_svc_tenant.go
+++ b/eureka-cli/managementsvc/management_svc_tenant.go
@@ -64,6 +64,15 @@ func (ms *ManagementSvc) CreateTenants() error {
 	tenantNames := helpers.SortedMapKeys(ms.Action.ConfigTenants)
 
 	for _, tenantName := range tenantNames {
+		existing, err := ms.getTenantByName(tenantName)
+		if err != nil {
+			return err
+		}
+		if existing != nil {
+			slog.Info(ms.Action.Name, "text", "Tenant already exists, skipping", "tenant", tenantName)
+			continue
+		}
+
 		properties := ms.Action.ConfigTenants[tenantName]
 		entry := properties.(map[string]any)
 		payload, err := json.Marshal(map[string]string{
@@ -82,6 +91,25 @@ func (ms *ManagementSvc) CreateTenants() error {
 	}
 
 	return nil
+}
+
+func (ms *ManagementSvc) getTenantByName(name string) (*models.Tenant, error) {
+	rawQuery := fmt.Sprintf("name==%s", name)
+	requestURL := ms.Action.GetRequestURL(constant.KongPort, fmt.Sprintf("/tenants?query=%s&limit=1", url.QueryEscape(rawQuery)))
+	headers, err := helpers.SecureApplicationJSONHeaders(ms.Action.KeycloakMasterAccessToken)
+	if err != nil {
+		return nil, err
+	}
+
+	var decodedResponse models.TenantsResponse
+	if err := ms.HTTPClient.GetRetryReturnStruct(requestURL, headers, &decodedResponse); err != nil {
+		return nil, err
+	}
+	if len(decodedResponse.Tenants) == 0 {
+		return nil, nil
+	}
+
+	return &decodedResponse.Tenants[0], nil
 }
 
 func (ms *ManagementSvc) GetTenantType(entry map[string]any) string {

--- a/eureka-cli/managementsvc/management_svc_tenant_entitlement.go
+++ b/eureka-cli/managementsvc/management_svc_tenant_entitlement.go
@@ -58,6 +58,22 @@ func (ms *ManagementSvc) CreateTenantEntitlement(consortiumName string, tenantTy
 			continue
 		}
 
+		existingEntitlements, err := ms.GetTenantEntitlements(tenantName, false)
+		if err != nil {
+			return err
+		}
+		alreadyEntitled := false
+		for _, e := range existingEntitlements.Entitlements {
+			if e.ApplicationID == ms.Action.ConfigApplicationID {
+				alreadyEntitled = true
+				break
+			}
+		}
+		if alreadyEntitled {
+			slog.Info(ms.Action.Name, "text", "Tenant entitlement already exists, skipping", "tenant", tenantName)
+			continue
+		}
+
 		payload, err := json.Marshal(map[string]any{
 			"tenantId":     helpers.GetString(entry, "id"),
 			"applications": []string{ms.Action.ConfigApplicationID},
@@ -72,7 +88,7 @@ func (ms *ManagementSvc) CreateTenantEntitlement(consortiumName string, tenantTy
 		}
 		slog.Info(ms.Action.Name, "text", "Created tenant entitlement", "tenant", tenantName, "flowId", decodedResponse.FlowID)
 
-	  time.Sleep(30 * time.Second)
+		time.Sleep(30 * time.Second)
 	}
 
 	return nil

--- a/eureka-cli/managementsvc/management_svc_test.go
+++ b/eureka-cli/managementsvc/management_svc_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/folio-org/eureka-setup/eureka-cli/constant"
+	apperrors "github.com/folio-org/eureka-setup/eureka-cli/errors"
 	"github.com/folio-org/eureka-setup/eureka-cli/internal/testhelpers"
 	"github.com/folio-org/eureka-setup/eureka-cli/managementsvc"
 	"github.com/folio-org/eureka-setup/eureka-cli/models"
@@ -698,6 +699,14 @@ func TestCreateTenants_Success(t *testing.T) {
 	mockTenantSvc := &MockTenantSvc{}
 	svc := managementsvc.New(action, mockHTTP, mockTenantSvc)
 
+	mockHTTP.On("GetRetryReturnStruct",
+		mock.MatchedBy(func(url string) bool {
+			return strings.Contains(url, "query=name%3D%3D")
+		}),
+		mock.Anything,
+		mock.Anything).
+		Return(nil)
+
 	mockHTTP.On("PostReturnStruct",
 		mock.MatchedBy(func(url string) bool {
 			return strings.Contains(url, "/tenants")
@@ -739,6 +748,14 @@ func TestCreateTenants_CentralTenant(t *testing.T) {
 	mockTenantSvc := &MockTenantSvc{}
 	svc := managementsvc.New(action, mockHTTP, mockTenantSvc)
 
+	mockHTTP.On("GetRetryReturnStruct",
+		mock.MatchedBy(func(url string) bool {
+			return strings.Contains(url, "query=name%3D%3D")
+		}),
+		mock.Anything,
+		mock.Anything).
+		Return(nil)
+
 	mockHTTP.On("PostReturnStruct",
 		mock.Anything,
 		mock.MatchedBy(func(payload []byte) bool {
@@ -774,6 +791,14 @@ func TestCreateTenants_HTTPError(t *testing.T) {
 	}
 	mockTenantSvc := &MockTenantSvc{}
 	svc := managementsvc.New(action, mockHTTP, mockTenantSvc)
+
+	mockHTTP.On("GetRetryReturnStruct",
+		mock.MatchedBy(func(url string) bool {
+			return strings.Contains(url, "query=name%3D%3D")
+		}),
+		mock.Anything,
+		mock.Anything).
+		Return(nil)
 
 	expectedError := errors.New("HTTP POST failed")
 	mockHTTP.On("PostReturnStruct",
@@ -879,6 +904,14 @@ func TestCreateTenantEntitlement_Success(t *testing.T) {
 			target := args.Get(2).(*models.TenantsResponse)
 			_ = json.Unmarshal([]byte(responseBody), target)
 		}).
+		Return(nil)
+
+	mockHTTP.On("GetReturnStruct",
+		mock.MatchedBy(func(url string) bool {
+			return strings.Contains(url, "/entitlements?tenant=")
+		}),
+		mock.Anything,
+		mock.Anything).
 		Return(nil)
 
 	mockHTTP.On("PostReturnStruct",
@@ -1066,6 +1099,14 @@ func TestCreateTenants_NoConsortium(t *testing.T) {
 	}
 	mockTenantSvc := &MockTenantSvc{}
 	svc := managementsvc.New(action, mockHTTP, mockTenantSvc)
+
+	mockHTTP.On("GetRetryReturnStruct",
+		mock.MatchedBy(func(url string) bool {
+			return strings.Contains(url, "query=name%3D%3D")
+		}),
+		mock.Anything,
+		mock.Anything).
+		Return(nil)
 
 	mockHTTP.On("PostReturnStruct",
 		mock.Anything,
@@ -1313,6 +1354,14 @@ func TestCreateTenantEntitlement_PostError(t *testing.T) {
 		}).
 		Return(nil)
 
+	mockHTTP.On("GetReturnStruct",
+		mock.MatchedBy(func(url string) bool {
+			return strings.Contains(url, "/entitlements?tenant=")
+		}),
+		mock.Anything,
+		mock.Anything).
+		Return(nil)
+
 	expectedError := errors.New("post failed")
 	mockHTTP.On("PostReturnStruct",
 		mock.Anything,
@@ -1408,6 +1457,15 @@ func TestCreateApplication_MinimalSuccess(t *testing.T) {
 		ModuleDescriptors: map[string]any{},
 	}
 
+	mockHTTP.On("GetRetryReturnStruct",
+		mock.MatchedBy(func(url string) bool {
+			return strings.Contains(url, "/applications/") && !strings.Contains(url, "?")
+		}),
+		mock.Anything,
+		mock.Anything).
+		Once().
+		Return(apperrors.ErrHTTP404NotFound)
+
 	mockHTTP.On("PostReturnStruct",
 		mock.MatchedBy(func(url string) bool {
 			return strings.Contains(url, "/applications")
@@ -1487,6 +1545,15 @@ func TestCreateApplication_WithFrontendModule(t *testing.T) {
 		ModuleDescriptors: map[string]any{},
 	}
 
+	mockHTTP.On("GetRetryReturnStruct",
+		mock.MatchedBy(func(url string) bool {
+			return strings.Contains(url, "/applications/") && !strings.Contains(url, "?")
+		}),
+		mock.Anything,
+		mock.Anything).
+		Once().
+		Return(apperrors.ErrHTTP404NotFound)
+
 	mockHTTP.On("PostReturnStruct",
 		mock.MatchedBy(func(url string) bool {
 			return strings.Contains(url, "/applications")
@@ -1550,6 +1617,15 @@ func TestCreateApplication_SkipsManagementModule(t *testing.T) {
 		ModuleDescriptors: map[string]any{},
 	}
 
+	mockHTTP.On("GetRetryReturnStruct",
+		mock.MatchedBy(func(url string) bool {
+			return strings.Contains(url, "/applications/") && !strings.Contains(url, "?")
+		}),
+		mock.Anything,
+		mock.Anything).
+		Once().
+		Return(apperrors.ErrHTTP404NotFound)
+
 	mockHTTP.On("PostReturnStruct",
 		mock.MatchedBy(func(url string) bool {
 			return strings.Contains(url, "/applications")
@@ -1599,6 +1675,15 @@ func TestCreateApplication_HTTPError(t *testing.T) {
 		FrontendModules:   map[string]models.FrontendModule{},
 		ModuleDescriptors: map[string]any{},
 	}
+
+	mockHTTP.On("GetRetryReturnStruct",
+		mock.MatchedBy(func(url string) bool {
+			return strings.Contains(url, "/applications/") && !strings.Contains(url, "?")
+		}),
+		mock.Anything,
+		mock.Anything).
+		Once().
+		Return(apperrors.ErrHTTP404NotFound)
 
 	expectedError := errors.New("HTTP POST failed")
 	mockHTTP.On("PostReturnStruct",
@@ -1654,6 +1739,15 @@ func TestCreateApplication_WithModuleVersionOverride(t *testing.T) {
 		FrontendModules:   map[string]models.FrontendModule{},
 		ModuleDescriptors: map[string]any{},
 	}
+
+	mockHTTP.On("GetRetryReturnStruct",
+		mock.MatchedBy(func(url string) bool {
+			return strings.Contains(url, "/applications/") && !strings.Contains(url, "?")
+		}),
+		mock.Anything,
+		mock.Anything).
+		Once().
+		Return(apperrors.ErrHTTP404NotFound)
 
 	mockHTTP.On("PostReturnStruct",
 		mock.MatchedBy(func(url string) bool {
@@ -1742,6 +1836,15 @@ func TestCreateApplication_WithFetchDescriptorsFromRemote(t *testing.T) {
 		"id":   "mod-test-1.0.0",
 		"name": "Test Module",
 	}
+
+	mockHTTP.On("GetRetryReturnStruct",
+		mock.MatchedBy(func(url string) bool {
+			return strings.Contains(url, "/applications/") && !strings.Contains(url, "?")
+		}),
+		mock.Anything,
+		mock.Anything).
+		Once().
+		Return(apperrors.ErrHTTP404NotFound)
 
 	// Mock the remote descriptor fetch
 	mockHTTP.On("GetRetryReturnStruct",
@@ -1874,6 +1977,15 @@ func TestCreateApplication_WithDependencies(t *testing.T) {
 		FrontendModules:   map[string]models.FrontendModule{},
 		ModuleDescriptors: map[string]any{},
 	}
+
+	mockHTTP.On("GetRetryReturnStruct",
+		mock.MatchedBy(func(url string) bool {
+			return strings.Contains(url, "/applications/") && !strings.Contains(url, "?")
+		}),
+		mock.Anything,
+		mock.Anything).
+		Once().
+		Return(apperrors.ErrHTTP404NotFound)
 
 	mockHTTP.On("PostReturnStruct",
 		mock.MatchedBy(func(url string) bool {
@@ -2027,6 +2139,15 @@ func TestCreateApplication_SkipsModuleNotInConfig(t *testing.T) {
 		ModuleDescriptors: map[string]any{},
 	}
 
+	mockHTTP.On("GetRetryReturnStruct",
+		mock.MatchedBy(func(url string) bool {
+			return strings.Contains(url, "/applications/") && !strings.Contains(url, "?")
+		}),
+		mock.Anything,
+		mock.Anything).
+		Once().
+		Return(apperrors.ErrHTTP404NotFound)
+
 	mockHTTP.On("PostReturnStruct",
 		mock.MatchedBy(func(url string) bool {
 			return strings.Contains(url, "/applications")
@@ -2090,6 +2211,15 @@ func TestCreateApplication_SkipsModuleWithDeployFalse(t *testing.T) {
 		FrontendModules:   map[string]models.FrontendModule{},
 		ModuleDescriptors: map[string]any{},
 	}
+
+	mockHTTP.On("GetRetryReturnStruct",
+		mock.MatchedBy(func(url string) bool {
+			return strings.Contains(url, "/applications/") && !strings.Contains(url, "?")
+		}),
+		mock.Anything,
+		mock.Anything).
+		Once().
+		Return(apperrors.ErrHTTP404NotFound)
 
 	mockHTTP.On("PostReturnStruct",
 		mock.MatchedBy(func(url string) bool {
@@ -2155,6 +2285,15 @@ func TestCreateApplication_WithEurekaModules(t *testing.T) {
 		FrontendModules:   map[string]models.FrontendModule{},
 		ModuleDescriptors: map[string]any{},
 	}
+
+	mockHTTP.On("GetRetryReturnStruct",
+		mock.MatchedBy(func(url string) bool {
+			return strings.Contains(url, "/applications/") && !strings.Contains(url, "?")
+		}),
+		mock.Anything,
+		mock.Anything).
+		Once().
+		Return(apperrors.ErrHTTP404NotFound)
 
 	mockHTTP.On("PostReturnStruct",
 		mock.MatchedBy(func(url string) bool {
@@ -2233,6 +2372,15 @@ func TestCreateApplication_DiscoveryPostError(t *testing.T) {
 		ModuleDescriptors: map[string]any{},
 	}
 
+	mockHTTP.On("GetRetryReturnStruct",
+		mock.MatchedBy(func(url string) bool {
+			return strings.Contains(url, "/applications/") && !strings.Contains(url, "?")
+		}),
+		mock.Anything,
+		mock.Anything).
+		Once().
+		Return(apperrors.ErrHTTP404NotFound)
+
 	mockHTTP.On("PostReturnStruct",
 		mock.MatchedBy(func(url string) bool {
 			return strings.Contains(url, "/applications")
@@ -2303,6 +2451,15 @@ func TestCreateApplication_WithModuleURLs(t *testing.T) {
 		FrontendModules:   map[string]models.FrontendModule{},
 		ModuleDescriptors: map[string]any{},
 	}
+
+	mockHTTP.On("GetRetryReturnStruct",
+		mock.MatchedBy(func(url string) bool {
+			return strings.Contains(url, "/applications/") && !strings.Contains(url, "?")
+		}),
+		mock.Anything,
+		mock.Anything).
+		Once().
+		Return(apperrors.ErrHTTP404NotFound)
 
 	mockHTTP.On("PostReturnStruct",
 		mock.MatchedBy(func(url string) bool {
@@ -2393,6 +2550,15 @@ func TestCreateApplication_FrontendModuleWithFetchDescriptors(t *testing.T) {
 
 	mockHTTP.On("GetRetryReturnStruct",
 		mock.MatchedBy(func(url string) bool {
+			return strings.Contains(url, "/applications/") && !strings.Contains(url, "?")
+		}),
+		mock.Anything,
+		mock.Anything).
+		Once().
+		Return(apperrors.ErrHTTP404NotFound)
+
+	mockHTTP.On("GetRetryReturnStruct",
+		mock.MatchedBy(func(url string) bool {
 			return strings.Contains(url, "/_/proxy/modules/folio-ui-1.0.0")
 		}),
 		mock.Anything,
@@ -2467,6 +2633,15 @@ func TestCreateApplication_FrontendModuleWithURL(t *testing.T) {
 		ModuleDescriptors: map[string]any{},
 	}
 
+	mockHTTP.On("GetRetryReturnStruct",
+		mock.MatchedBy(func(url string) bool {
+			return strings.Contains(url, "/applications/") && !strings.Contains(url, "?")
+		}),
+		mock.Anything,
+		mock.Anything).
+		Once().
+		Return(apperrors.ErrHTTP404NotFound)
+
 	mockHTTP.On("PostReturnStruct",
 		mock.MatchedBy(func(url string) bool {
 			return strings.Contains(url, "/applications")
@@ -2536,6 +2711,15 @@ func TestCreateApplication_FrontendVersionOverride(t *testing.T) {
 		},
 		ModuleDescriptors: map[string]any{},
 	}
+
+	mockHTTP.On("GetRetryReturnStruct",
+		mock.MatchedBy(func(url string) bool {
+			return strings.Contains(url, "/applications/") && !strings.Contains(url, "?")
+		}),
+		mock.Anything,
+		mock.Anything).
+		Once().
+		Return(apperrors.ErrHTTP404NotFound)
 
 	mockHTTP.On("PostReturnStruct",
 		mock.MatchedBy(func(url string) bool {
@@ -2616,6 +2800,15 @@ func TestCreateApplication_MixedBackendAndFrontend(t *testing.T) {
 		},
 		ModuleDescriptors: map[string]any{},
 	}
+
+	mockHTTP.On("GetRetryReturnStruct",
+		mock.MatchedBy(func(url string) bool {
+			return strings.Contains(url, "/applications/") && !strings.Contains(url, "?")
+		}),
+		mock.Anything,
+		mock.Anything).
+		Once().
+		Return(apperrors.ErrHTTP404NotFound)
 
 	mockHTTP.On("PostReturnStruct",
 		mock.MatchedBy(func(url string) bool {
@@ -2709,6 +2902,15 @@ func TestCreateApplication_BothModulesBackendVersionOverride(t *testing.T) {
 		ModuleDescriptors: map[string]any{},
 	}
 
+	mockHTTP.On("GetRetryReturnStruct",
+		mock.MatchedBy(func(url string) bool {
+			return strings.Contains(url, "/applications/") && !strings.Contains(url, "?")
+		}),
+		mock.Anything,
+		mock.Anything).
+		Once().
+		Return(apperrors.ErrHTTP404NotFound)
+
 	mockHTTP.On("PostReturnStruct",
 		mock.MatchedBy(func(url string) bool {
 			return strings.Contains(url, "/applications")
@@ -2800,6 +3002,15 @@ func TestCreateApplication_BothModulesFrontendVersionOverride(t *testing.T) {
 		},
 		ModuleDescriptors: map[string]any{},
 	}
+
+	mockHTTP.On("GetRetryReturnStruct",
+		mock.MatchedBy(func(url string) bool {
+			return strings.Contains(url, "/applications/") && !strings.Contains(url, "?")
+		}),
+		mock.Anything,
+		mock.Anything).
+		Once().
+		Return(apperrors.ErrHTTP404NotFound)
 
 	mockHTTP.On("PostReturnStruct",
 		mock.MatchedBy(func(url string) bool {
@@ -2894,6 +3105,15 @@ func TestCreateApplication_BothModulesBothVersionOverrides(t *testing.T) {
 		},
 		ModuleDescriptors: map[string]any{},
 	}
+
+	mockHTTP.On("GetRetryReturnStruct",
+		mock.MatchedBy(func(url string) bool {
+			return strings.Contains(url, "/applications/") && !strings.Contains(url, "?")
+		}),
+		mock.Anything,
+		mock.Anything).
+		Once().
+		Return(apperrors.ErrHTTP404NotFound)
 
 	mockHTTP.On("PostReturnStruct",
 		mock.MatchedBy(func(url string) bool {
@@ -3844,4 +4064,128 @@ func TestCreateNewModuleDiscovery_HTTPError(t *testing.T) {
 	assert.Error(t, err)
 	assert.Equal(t, expectedError, err)
 	mockHTTP.AssertExpectations(t)
+}
+
+// ==================== Idempotency Tests ====================
+
+func TestCreateTenants_TenantAlreadyExists_Skipped(t *testing.T) {
+	// Arrange
+	mockHTTP := &testhelpers.MockHTTPClient{}
+	action := testhelpers.NewMockAction()
+	action.KeycloakMasterAccessToken = "test-token"
+	action.ConfigTenants = map[string]any{
+		"test-tenant": map[string]any{
+			"consortium": "test-consortium",
+		},
+	}
+	mockTenantSvc := &MockTenantSvc{}
+	svc := managementsvc.New(action, mockHTTP, mockTenantSvc)
+
+	mockHTTP.On("GetRetryReturnStruct",
+		mock.MatchedBy(func(url string) bool {
+			return strings.Contains(url, "query=name%3D%3D")
+		}),
+		mock.Anything,
+		mock.Anything).
+		Run(func(args mock.Arguments) {
+			target := args.Get(2).(*models.TenantsResponse)
+			target.Tenants = []models.Tenant{{ID: "existing-id", Name: "test-tenant"}}
+		}).
+		Return(nil)
+
+	// Act
+	err := svc.CreateTenants()
+
+	// Assert
+	assert.NoError(t, err)
+	mockHTTP.AssertNotCalled(t, "PostReturnStruct", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+}
+
+func TestCreateApplication_AlreadyExists_Skipped(t *testing.T) {
+	// Arrange
+	mockHTTP := &testhelpers.MockHTTPClient{}
+	action := testhelpers.NewMockAction()
+	action.KeycloakMasterAccessToken = "test-token"
+	action.ConfigApplicationID = "test-app"
+	mockTenantSvc := &MockTenantSvc{}
+	svc := managementsvc.New(action, mockHTTP, mockTenantSvc)
+
+	extract := &models.RegistryExtract{
+		Modules: &models.ProxyModulesByRegistry{
+			FolioModules:  []*models.ProxyModule{},
+			EurekaModules: []*models.ProxyModule{},
+		},
+		BackendModules:    map[string]models.BackendModule{},
+		FrontendModules:   map[string]models.FrontendModule{},
+		ModuleDescriptors: map[string]any{},
+	}
+
+	mockHTTP.On("GetRetryReturnStruct",
+		mock.MatchedBy(func(url string) bool {
+			return strings.Contains(url, "/applications/test-app")
+		}),
+		mock.Anything,
+		mock.Anything).
+		Run(func(args mock.Arguments) {
+			target := args.Get(2).(*map[string]any)
+			*target = map[string]any{"id": "test-app", "name": "Test App"}
+		}).
+		Return(nil)
+
+	// Act
+	err := svc.CreateApplication(extract)
+
+	// Assert
+	assert.NoError(t, err)
+	mockHTTP.AssertNotCalled(t, "PostReturnStruct", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+}
+
+func TestCreateTenantEntitlement_AlreadyEntitled_Skipped(t *testing.T) {
+	// Arrange
+	mockHTTP := &testhelpers.MockHTTPClient{}
+	action := testhelpers.NewMockAction()
+	action.KeycloakMasterAccessToken = "test-token"
+	action.ConfigTenants = map[string]any{
+		"test-tenant": map[string]any{},
+	}
+	action.ConfigApplicationID = "app-123"
+	mockTenantSvc := &MockTenantSvc{}
+	svc := managementsvc.New(action, mockHTTP, mockTenantSvc)
+
+	mockTenantSvc.On("GetEntitlementTenantParameters", "test-consortium").
+		Return("param1=value1", nil)
+
+	responseBody := `{"tenants": [{"id": "tenant-123", "name": "test-tenant"}], "totalRecords": 1}`
+	mockHTTP.On("GetRetryReturnStruct",
+		mock.Anything,
+		mock.Anything,
+		mock.Anything).
+		Run(func(args mock.Arguments) {
+			target := args.Get(2).(*models.TenantsResponse)
+			_ = json.Unmarshal([]byte(responseBody), target)
+		}).
+		Return(nil)
+
+	mockHTTP.On("GetReturnStruct",
+		mock.MatchedBy(func(url string) bool {
+			return strings.Contains(url, "/entitlements?tenant=")
+		}),
+		mock.Anything,
+		mock.Anything).
+		Run(func(args mock.Arguments) {
+			target := args.Get(2).(*models.TenantEntitlementResponse)
+			target.Entitlements = []models.TenantEntitlementDTO{
+				{ApplicationID: "app-123", TenantID: "tenant-123"},
+			}
+			target.TotalRecords = 1
+		}).
+		Return(nil)
+
+	// Act
+	err := svc.CreateTenantEntitlement("test-consortium", constant.TenantType(constant.Member))
+
+	// Assert
+	assert.NoError(t, err)
+	mockHTTP.AssertNotCalled(t, "PostReturnStruct", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+	mockTenantSvc.AssertExpectations(t)
 }

--- a/eureka-cli/moduleprops/module_props.go
+++ b/eureka-cli/moduleprops/module_props.go
@@ -56,17 +56,9 @@ func (mp *ModuleProps) ReadBackendModules(isManagement bool, verbose bool) (map[
 		modules[name] = *backendModule
 		if verbose {
 			if p.Version == nil {
-				slog.Info(mp.Action.Name, "text", "Read backend module", "module", name,
-					"port1", modules[name].ModuleExposedServerPort,
-					"port2", modules[name].ModuleExposedDebugPort,
-					"port3", modules[name].SidecarExposedServerPort,
-					"port4", modules[name].SidecarExposedDebugPort)
+				slog.Info(mp.Action.Name, "text", "Read backend module", "module", name)
 			} else {
-				slog.Info(mp.Action.Name, "text", "Read backend module", "module", name, "version", *p.Version,
-					"port1", modules[name].ModuleExposedServerPort,
-					"port2", modules[name].ModuleExposedDebugPort,
-					"port3", modules[name].SidecarExposedServerPort,
-					"port4", modules[name].SidecarExposedDebugPort)
+				slog.Info(mp.Action.Name, "text", "Read backend module", "module", name, "version", *p.Version)
 			}
 		}
 	}

--- a/eureka-cli/modulesvc/module_svc_manage.go
+++ b/eureka-cli/modulesvc/module_svc_manage.go
@@ -61,7 +61,7 @@ func (ms *ModuleSvc) GetModule(client *client.Client, moduleName string) ([]cont
 func (ms *ModuleSvc) PullModule(client *client.Client, imageName string) error {
 	_, err := client.ImageInspect(context.Background(), imageName)
 	if err == nil {
-		slog.Debug(ms.Action.Name, "text", "Image already exists locally", "image", imageName)
+		slog.Info(ms.Action.Name, "text", "Image already exists locally", "image", imageName)
 		return nil
 	}
 	if !errdefs.IsNotFound(err) {

--- a/eureka-cli/modulesvc/module_svc_manage.go
+++ b/eureka-cli/modulesvc/module_svc_manage.go
@@ -24,8 +24,9 @@ import (
 // ModuleManager defines the interface for managing module deployment and lifecycle
 type ModuleManager interface {
 	GetDeployedModules(client *client.Client, filters filters.Args) ([]container.Summary, error)
+	GetModule(client *client.Client, moduleName string) ([]container.Summary, error)
 	PullModule(client *client.Client, imageName string) error
-	DeployModules(client *client.Client, containers *models.Containers, sidecarImage string, sidecarResources *container.Resources) (map[string]int, error)
+	DeployModules(client *client.Client, containers *models.Containers, sidecarImage string, sidecarResources *container.Resources) (map[string]int, int, error)
 	DeployModule(client *client.Client, container *models.Container) error
 	UndeployModuleByNamePattern(client *client.Client, pattern string) error
 }
@@ -43,6 +44,18 @@ func (ms *ModuleSvc) GetDeployedModules(client *client.Client, filters filters.A
 	}
 
 	return deployedModules, nil
+}
+
+func (ms *ModuleSvc) GetModule(client *client.Client, moduleName string) ([]container.Summary, error) {
+	containerName := fmt.Sprintf("eureka-%s-%s", ms.Action.ConfigProfileName, moduleName)
+	if strings.HasPrefix(moduleName, constant.ManagementModulePattern) {
+		containerName = fmt.Sprintf("eureka-%s", moduleName)
+	}
+
+	return ms.GetDeployedModules(client, filters.NewArgs(filters.KeyValuePair{
+		Key:   "name",
+		Value: fmt.Sprintf("^%s$", containerName),
+	}))
 }
 
 func (ms *ModuleSvc) PullModule(client *client.Client, imageName string) error {
@@ -90,8 +103,9 @@ func (ms *ModuleSvc) PullModule(client *client.Client, imageName string) error {
 	return nil
 }
 
-func (ms *ModuleSvc) DeployModules(client *client.Client, containers *models.Containers, sidecarImage string, sidecarResources *container.Resources) (map[string]int, error) {
-	deployedModules := make(map[string]int)
+func (ms *ModuleSvc) DeployModules(client *client.Client, containers *models.Containers, sidecarImage string, sidecarResources *container.Resources) (map[string]int, int, error) {
+	newlyDeployed := make(map[string]int)
+	totalMatched := 0
 
 	var sidecarWG sync.WaitGroup
 	sidecarErrCh := make(chan error, 10)
@@ -106,6 +120,17 @@ func (ms *ModuleSvc) DeployModules(client *client.Client, containers *models.Con
 			}
 
 			backendModule := containers.BackendModules[module.Metadata.Name]
+			totalMatched++
+
+			existingContainers, err := ms.GetModule(client, module.Metadata.Name)
+			if err != nil {
+				return nil, 0, err
+			}
+			if len(existingContainers) > 0 {
+				slog.Info(ms.Action.Name, "text", "Container already deployed, skipping", "module", module.Metadata.Name)
+				continue
+			}
+
 			version := ms.GetModuleImageVersion(backendModule, module)
 			module.Metadata.Version = &version
 
@@ -127,9 +152,9 @@ func (ms *ModuleSvc) DeployModules(client *client.Client, containers *models.Con
 				Platform:      helpers.GetPlatform(),
 				PullImage:     backendModule.LocalDescriptorPath == "",
 			}); err != nil {
-				return nil, err
+				return nil, 0, err
 			}
-			deployedModules[module.Metadata.Name] = backendModule.ModuleExposedServerPort
+			newlyDeployed[module.Metadata.Name] = backendModule.ModuleExposedServerPort
 
 			if backendModule.DeploySidecar && sidecarImage != "" {
 				sidecarWG.Add(1)
@@ -150,10 +175,10 @@ func (ms *ModuleSvc) DeployModules(client *client.Client, containers *models.Con
 		close(sidecarErrCh)
 	}()
 	for err := range sidecarErrCh {
-		return nil, err
+		return nil, 0, err
 	}
 
-	return deployedModules, nil
+	return newlyDeployed, totalMatched, nil
 }
 
 func (ms *ModuleSvc) shouldSkipModule(module *models.ProxyModule, managementOnly bool) bool {

--- a/eureka-cli/modulesvc/module_svc_manage.go
+++ b/eureka-cli/modulesvc/module_svc_manage.go
@@ -127,12 +127,21 @@ func (ms *ModuleSvc) DeployModules(client *client.Client, containers *models.Con
 				return nil, 0, err
 			}
 			if len(existingContainers) > 0 {
-				slog.Info(ms.Action.Name, "text", "Container already deployed, skipping", "module", module.Metadata.Name)
+				var portParts []string
+				for _, p := range existingContainers[0].Ports {
+					portParts = append(portParts, fmt.Sprintf("%d->%d/%s", p.PublicPort, p.PrivatePort, p.Type))
+				}
+				slog.Info(ms.Action.Name, "text", "Container already deployed, skipping", "module", module.Metadata.Name, "ports", strings.Join(portParts, ", "))
 				continue
 			}
 
 			version := ms.GetModuleImageVersion(backendModule, module)
 			module.Metadata.Version = &version
+			slog.Info(ms.Action.Name, "text", "Deploying module", "module", module.Metadata.Name,
+				"port1", backendModule.ModuleExposedServerPort,
+				"port2", backendModule.ModuleExposedDebugPort,
+				"port3", backendModule.SidecarExposedServerPort,
+				"port4", backendModule.SidecarExposedDebugPort)
 
 			if err := ms.DeployModule(client, &models.Container{
 				Name: module.Metadata.Name,

--- a/eureka-cli/modulesvc/module_svc_test.go
+++ b/eureka-cli/modulesvc/module_svc_test.go
@@ -1,19 +1,24 @@
 package modulesvc
 
 import (
+	"encoding/json"
 	"errors"
 	"net/http"
+	"net/http/httptest"
 	"strings"
 	"sync"
 	"testing"
 	"time"
 
+	dockertypes "github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/client"
 	"github.com/folio-org/eureka-setup/eureka-cli/constant"
 	"github.com/folio-org/eureka-setup/eureka-cli/field"
 	"github.com/folio-org/eureka-setup/eureka-cli/internal/testhelpers"
 	"github.com/folio-org/eureka-setup/eureka-cli/models"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNew(t *testing.T) {
@@ -1369,4 +1374,101 @@ func TestGetLocalModuleImage_LatestTag(t *testing.T) {
 
 	// Assert
 	assert.Equal(t, "docker.io/folioorg/mod-latest:latest", result)
+}
+
+func newDockerTestServer(t *testing.T, summaries []dockertypes.Summary, statusCode int) (*httptest.Server, *client.Client) {
+	t.Helper()
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/containers/json") {
+			w.Header().Set("Content-Type", "application/json")
+			if statusCode != http.StatusOK {
+				w.WriteHeader(statusCode)
+				return
+			}
+			_ = json.NewEncoder(w).Encode(summaries)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	cli, err := client.NewClientWithOpts(client.WithHost(ts.URL), client.WithVersion("1.41"))
+	require.NoError(t, err)
+	t.Cleanup(ts.Close)
+	return ts, cli
+}
+
+func TestGetModule_RegularModule_Found(t *testing.T) {
+	// Arrange
+	summaries := []dockertypes.Summary{{ID: "abc123"}}
+	_, dockerClient := newDockerTestServer(t, summaries, http.StatusOK)
+
+	action := testhelpers.NewMockAction()
+	svc := New(action, nil, nil, nil, nil)
+
+	// Act
+	result, err := svc.GetModule(dockerClient, "mod-test")
+
+	// Assert
+	assert.NoError(t, err)
+	assert.Len(t, result, 1)
+	assert.Equal(t, "abc123", result[0].ID)
+}
+
+func TestGetModule_ManagementModule_SkipsProfilePrefix(t *testing.T) {
+	// Arrange — capture the filter to verify no profile name is prepended
+	var capturedFilter string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/containers/json") {
+			capturedFilter = r.URL.Query().Get("filters")
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode([]dockertypes.Summary{{ID: "def456"}})
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(ts.Close)
+	dockerClient, err := client.NewClientWithOpts(client.WithHost(ts.URL), client.WithVersion("1.41"))
+	require.NoError(t, err)
+
+	action := testhelpers.NewMockAction()
+	svc := New(action, nil, nil, nil, nil)
+
+	// Act
+	result, err := svc.GetModule(dockerClient, "mgr-tenants")
+
+	// Assert
+	assert.NoError(t, err)
+	assert.Len(t, result, 1)
+	// Filter must reference "eureka-mgr-tenants", not "eureka--mgr-tenants"
+	assert.Contains(t, capturedFilter, "eureka-mgr-tenants")
+	assert.NotContains(t, capturedFilter, "eureka--mgr-tenants")
+}
+
+func TestGetModule_NotFound_ReturnsEmpty(t *testing.T) {
+	// Arrange
+	_, dockerClient := newDockerTestServer(t, []dockertypes.Summary{}, http.StatusOK)
+
+	action := testhelpers.NewMockAction()
+	svc := New(action, nil, nil, nil, nil)
+
+	// Act
+	result, err := svc.GetModule(dockerClient, "mod-missing")
+
+	// Assert
+	assert.NoError(t, err)
+	assert.Empty(t, result)
+}
+
+func TestGetModule_DockerError_Propagates(t *testing.T) {
+	// Arrange
+	_, dockerClient := newDockerTestServer(t, nil, http.StatusInternalServerError)
+
+	action := testhelpers.NewMockAction()
+	svc := New(action, nil, nil, nil, nil)
+
+	// Act
+	result, err := svc.GetModule(dockerClient, "mod-test")
+
+	// Assert
+	assert.Error(t, err)
+	assert.Nil(t, result)
 }

--- a/eureka-cli/registrysvc/registry_svc.go
+++ b/eureka-cli/registrysvc/registry_svc.go
@@ -146,7 +146,6 @@ func (rs *RegistrySvc) fetchAndPersistModuleVersions(filePath string) ([]models.
 	if err := rs.HTTPClient.GetRetryReturnStruct(rs.Action.ConfigLspURL, map[string]string{}, &descriptor); err != nil {
 		return nil, err
 	}
-
 	slog.Info(rs.Action.Name, "text", "Fetched LSP platform descriptor", "name", descriptor.Name, "version", descriptor.Version)
 
 	applications := append(descriptor.Applications.Required, descriptor.Applications.Optional...)

--- a/eureka-cli/uisvc/ui_svc.go
+++ b/eureka-cli/uisvc/ui_svc.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"os/exec"
 	"path/filepath"
+	"strings"
 
 	"github.com/folio-org/eureka-setup/eureka-cli/action"
 	"github.com/folio-org/eureka-setup/eureka-cli/constant"
@@ -142,7 +143,20 @@ func (us *UISvc) BuildImage(tenantName string, outputDir string) (string, error)
 func (us *UISvc) DeployContainer(tenantName string, imageName string, externalPort int) error {
 	slog.Info(us.Action.Name, "text", "Deploying UI container for tenant", "tenant", tenantName)
 	containerName := fmt.Sprintf("eureka-platform-complete-ui-%s", tenantName)
-	err := us.ExecSvc.Exec(exec.Command("docker", "run", "--name", containerName,
+
+	stdout, _, err := us.ExecSvc.ExecReturnOutput(exec.Command("docker", "ps", "-a",
+		"--filter", fmt.Sprintf("name=^%s$", containerName),
+		"--format", "{{.Names}}",
+	))
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(stdout.String()) != "" {
+		slog.Info(us.Action.Name, "text", "UI container already deployed, skipping", "tenant", tenantName)
+		return nil
+	}
+
+	err = us.ExecSvc.Exec(exec.Command("docker", "run", "--name", containerName,
 		"--hostname", containerName,
 		"--publish", fmt.Sprintf("%d:80", externalPort),
 		"--restart", "unless-stopped",

--- a/eureka-cli/uisvc/ui_svc_test.go
+++ b/eureka-cli/uisvc/ui_svc_test.go
@@ -1,6 +1,7 @@
 package uisvc
 
 import (
+	"bytes"
 	"errors"
 	"os/exec"
 	"path/filepath"
@@ -312,6 +313,11 @@ func TestDeployContainer_Success(t *testing.T) {
 	mockExec := new(testhelpers.MockCommandExecutor)
 	svc := New(action, mockExec, nil, nil, nil)
 
+	// Mock docker ps -a (container not found)
+	mockExec.On("ExecReturnOutput", mock.MatchedBy(func(cmd *exec.Cmd) bool {
+		return len(cmd.Args) >= 2 && cmd.Args[0] == "docker" && cmd.Args[1] == "ps"
+	})).Return(bytes.Buffer{}, bytes.Buffer{}, nil).Once()
+
 	// Mock docker run command
 	mockExec.On("Exec", mock.MatchedBy(func(cmd *exec.Cmd) bool {
 		return len(cmd.Args) >= 2 &&
@@ -341,6 +347,11 @@ func TestDeployContainer_RunError(t *testing.T) {
 	mockExec := new(testhelpers.MockCommandExecutor)
 	svc := New(action, mockExec, nil, nil, nil)
 
+	// Mock docker ps -a (container not found)
+	mockExec.On("ExecReturnOutput", mock.MatchedBy(func(cmd *exec.Cmd) bool {
+		return len(cmd.Args) >= 2 && cmd.Args[0] == "docker" && cmd.Args[1] == "ps"
+	})).Return(bytes.Buffer{}, bytes.Buffer{}, nil).Once()
+
 	runErr := errors.New("docker run failed")
 	mockExec.On("Exec", mock.MatchedBy(func(cmd *exec.Cmd) bool {
 		return len(cmd.Args) >= 2 &&
@@ -362,6 +373,11 @@ func TestDeployContainer_NetworkConnectError(t *testing.T) {
 	action := testhelpers.NewMockAction()
 	mockExec := new(testhelpers.MockCommandExecutor)
 	svc := New(action, mockExec, nil, nil, nil)
+
+	// Mock docker ps -a (container not found)
+	mockExec.On("ExecReturnOutput", mock.MatchedBy(func(cmd *exec.Cmd) bool {
+		return len(cmd.Args) >= 2 && cmd.Args[0] == "docker" && cmd.Args[1] == "ps"
+	})).Return(bytes.Buffer{}, bytes.Buffer{}, nil).Once()
 
 	networkErr := errors.New("network connect failed")
 
@@ -395,6 +411,11 @@ func TestDeployContainer_VerifyContainerName(t *testing.T) {
 
 	var capturedContainerName string
 
+	// Mock docker ps -a (container not found)
+	mockExec.On("ExecReturnOutput", mock.MatchedBy(func(cmd *exec.Cmd) bool {
+		return len(cmd.Args) >= 2 && cmd.Args[0] == "docker" && cmd.Args[1] == "ps"
+	})).Return(bytes.Buffer{}, bytes.Buffer{}, nil).Once()
+
 	mockExec.On("Exec", mock.MatchedBy(func(cmd *exec.Cmd) bool {
 		if len(cmd.Args) >= 5 && cmd.Args[1] == "run" && cmd.Args[2] == "--name" {
 			capturedContainerName = cmd.Args[3]
@@ -423,6 +444,11 @@ func TestDeployContainer_VerifyPort(t *testing.T) {
 	svc := New(action, mockExec, nil, nil, nil)
 
 	var capturedPort string
+
+	// Mock docker ps -a (container not found)
+	mockExec.On("ExecReturnOutput", mock.MatchedBy(func(cmd *exec.Cmd) bool {
+		return len(cmd.Args) >= 2 && cmd.Args[0] == "docker" && cmd.Args[1] == "ps"
+	})).Return(bytes.Buffer{}, bytes.Buffer{}, nil).Once()
 
 	mockExec.On("Exec", mock.MatchedBy(func(cmd *exec.Cmd) bool {
 		if len(cmd.Args) >= 7 && cmd.Args[1] == "run" && cmd.Args[6] == "--publish" {
@@ -928,4 +954,25 @@ func TestPreparePackageJSON_EmptyDependencies(t *testing.T) {
 	assert.Equal(t, ">=1.0.0", result.Dependencies["@folio/authorization-roles"])
 	assert.Equal(t, ">=1.0.0", result.Dependencies["@folio/plugin-select-application"])
 	assert.Equal(t, ">=1.0.0", result.Dependencies["@folio/consortia-settings"])
+}
+
+func TestDeployContainer_AlreadyExists_Skipped(t *testing.T) {
+	// Arrange
+	action := testhelpers.NewMockAction()
+	mockExec := new(testhelpers.MockCommandExecutor)
+	svc := New(action, mockExec, nil, nil, nil)
+
+	// Mock docker ps -a returning the container name (already exists)
+	var existingName bytes.Buffer
+	existingName.WriteString("eureka-platform-complete-ui-test-tenant")
+	mockExec.On("ExecReturnOutput", mock.MatchedBy(func(cmd *exec.Cmd) bool {
+		return len(cmd.Args) >= 2 && cmd.Args[0] == "docker" && cmd.Args[1] == "ps"
+	})).Return(existingName, bytes.Buffer{}, nil).Once()
+
+	// Act
+	err := svc.DeployContainer("test-tenant", "test-image:latest", 8080)
+
+	// Assert — no docker run, no network connect
+	assert.NoError(t, err)
+	mockExec.AssertExpectations(t)
 }


### PR DESCRIPTION
## Purpose

- <https://folio-org.atlassian.net/browse/ECLI-3>

## Approach

- Make all primary mutating commands idempotent, i.e. non-falling if the desired state was met
- Update tests, internal/ and AGENTS.md