### PR TITLE
[ECLI-3]. Enhance git and http logging

### DIFF
--- a/eureka-cli/cmd/attachCapabilitySets.go
+++ b/eureka-cli/cmd/attachCapabilitySets.go
@@ -16,13 +16,22 @@ limitations under the License.
 package cmd
 
 import (
+	"fmt"
 	"log/slog"
+	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/folio-org/eureka-setup/eureka-cli/action"
 	"github.com/folio-org/eureka-setup/eureka-cli/constant"
+	"github.com/folio-org/eureka-setup/eureka-cli/helpers"
 	"github.com/spf13/cobra"
 )
+
+type capabilitySetsRecord struct {
+	Tenant string `json:"tenant"`
+	Total  int    `json:"total"`
+}
 
 // attachCapabilitySetsCmd represents the attachCapabilitySets command
 var attachCapabilitySetsCmd = &cobra.Command{
@@ -36,12 +45,12 @@ var attachCapabilitySetsCmd = &cobra.Command{
 		}
 
 		return run.ConsortiumPartition(func(consortiumName string, tenantType constant.TenantType) error {
-			return run.AttachCapabilitySets(consortiumName, tenantType, time.Duration(0*time.Second))
+			return run.AttachCapabilitySets(consortiumName, tenantType, time.Duration(0*time.Second), false)
 		})
 	},
 }
 
-func (run *Run) AttachCapabilitySets(consortiumName string, tenantType constant.TenantType, initialWait time.Duration) error {
+func (run *Run) AttachCapabilitySets(consortiumName string, tenantType constant.TenantType, initialWait time.Duration, forceRefresh bool) error {
 	if err := run.setKeycloakMasterAccessTokenIntoContext(constant.Password); err != nil {
 		return err
 	}
@@ -54,24 +63,59 @@ func (run *Run) AttachCapabilitySets(consortiumName string, tenantType constant.
 			return err
 		}
 
-		slog.Info(run.Config.Action.Name, "text", "CHECKING IF CAPABILITY SETS ALREADY EXIST", "tenant", configTenant)
-		hasCapabilitySets, err := run.Config.KeycloakSvc.HasCapabilitySets(configTenant)
+		slog.Info(run.Config.Action.Name, "text", "ATTACHING CAPABILITY SETS", "tenant", configTenant)
+		homeDir, err := helpers.GetHomeDirPath()
 		if err != nil {
 			return err
 		}
+		filePath := filepath.Join(homeDir, fmt.Sprintf(constant.CapabilitySetsFilePattern, configTenant))
 
-		if !hasCapabilitySets {
+		if forceRefresh {
+			if err := os.Remove(filePath); err != nil && !os.IsNotExist(err) {
+				slog.Warn(run.Config.Action.Name, "text", "Could not delete capability sets file", "tenant", configTenant, "error", err)
+			}
+		}
+
+		skipPoll := false
+		var record capabilitySetsRecord
+		if err := helpers.ReadJSONFromFile(filePath, &record); err == nil && record.Total > 0 {
+			liveCount, countErr := run.Config.KeycloakSvc.CountCapabilitySets(configTenant)
+			if countErr != nil {
+				slog.Warn(run.Config.Action.Name, "text", "Could not count capability sets, polling broker", "tenant", configTenant, "error", countErr)
+			} else if liveCount == record.Total {
+				slog.Info(run.Config.Action.Name, "text", "Capability sets match persisted count, skipping Kafka poll",
+					"tenant", configTenant, "total", liveCount)
+				skipPoll = true
+			} else {
+				slog.Info(run.Config.Action.Name, "text", "Capability sets count changed, polling broker",
+					"tenant", configTenant, "persisted", record.Total, "live", liveCount)
+			}
+		} else {
+			slog.Info(run.Config.Action.Name, "text", "No capability sets file found, polling broker", "tenant", configTenant)
+		}
+		if !skipPoll {
 			topicConfigTenant := run.Config.Action.GetKafkaTopicConfigTenant(configTenant)
 			slog.Info(run.Config.Action.Name, "text", "POLLING FOR CAPABILITY SETS CREATION", "topicConfigTenant", topicConfigTenant)
 			if err := run.Config.KafkaSvc.PollConsumerGroup(topicConfigTenant); err != nil {
 				return err
 			}
-		} else {
-			slog.Info(run.Config.Action.Name, "text", "Capability sets already exist, skipping Kafka poll", "tenant", configTenant)
+		}
+		if err := run.Config.KeycloakSvc.AttachCapabilitySetsToRoles(configTenant); err != nil {
+			return err
 		}
 
-		slog.Info(run.Config.Action.Name, "text", "ATTACHING CAPABILITY SETS", "tenant", configTenant)
-		return run.Config.KeycloakSvc.AttachCapabilitySetsToRoles(configTenant)
+		count, err := run.Config.KeycloakSvc.CountCapabilitySets(configTenant)
+		if err != nil {
+			slog.Warn(run.Config.Action.Name, "text", "Could not count capability sets, skipping persistence", "tenant", configTenant, "error", err)
+			return nil
+		}
+		if err := helpers.WriteJSONToFile(filePath, capabilitySetsRecord{Tenant: configTenant, Total: count}); err != nil {
+			slog.Warn(run.Config.Action.Name, "text", "Could not write capability sets file", "tenant", configTenant, "error", err)
+		} else {
+			slog.Info(run.Config.Action.Name, "text", "Persisted capability sets count", "tenant", configTenant, "total", count)
+		}
+
+		return nil
 	})
 }
 

--- a/eureka-cli/cmd/buildSystem.go
+++ b/eureka-cli/cmd/buildSystem.go
@@ -16,6 +16,7 @@ limitations under the License.
 package cmd
 
 import (
+	"errors"
 	"log/slog"
 	"os/exec"
 	"time"
@@ -23,6 +24,7 @@ import (
 	"github.com/folio-org/eureka-setup/eureka-cli/action"
 	"github.com/folio-org/eureka-setup/eureka-cli/gitrepository"
 	"github.com/folio-org/eureka-setup/eureka-cli/helpers"
+	git "github.com/go-git/go-git/v5"
 	"github.com/spf13/cobra"
 )
 
@@ -66,7 +68,11 @@ func (run *Run) CloneUpdateRepositories() error {
 	slog.Info(run.Config.Action.Name, "text", "Cloning repositories", "repositories", repositories)
 	for _, repository := range repositories {
 		if err := run.Config.GitClient.Clone(repository); err != nil {
-			slog.Warn(run.Config.Action.Name, "text", "Cloning was unsuccessful", "error", err)
+			if errors.Is(err, git.ErrRepositoryAlreadyExists) {
+				slog.Info(run.Config.Action.Name, "text", "Repository already cloned, skipping", "label", repository.Label)
+			} else {
+				slog.Warn(run.Config.Action.Name, "text", "Cloning was unsuccessful", "error", err)
+			}
 		}
 	}
 

--- a/eureka-cli/cmd/cmd_test.go
+++ b/eureka-cli/cmd/cmd_test.go
@@ -3,7 +3,11 @@ package cmd
 import (
 	"bytes"
 	"context"
+	"encoding/json"
+	"fmt"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"sync"
 	"testing"
 
@@ -213,6 +217,11 @@ func (m *MockKeycloakSvc) GetCapabilitySetsByName(headers map[string]string, cap
 func (m *MockKeycloakSvc) HasCapabilitySets(tenantName string) (bool, error) {
 	args := m.Called(tenantName)
 	return args.Bool(0), args.Error(1)
+}
+
+func (m *MockKeycloakSvc) CountCapabilitySets(tenantName string) (int, error) {
+	args := m.Called(tenantName)
+	return args.Int(0), args.Error(1)
 }
 
 func (m *MockKeycloakSvc) AttachCapabilitySets(tenantName string) error {
@@ -1615,6 +1624,13 @@ func TestAttachCapabilitySets_Success(t *testing.T) {
 	mockKafkaSvc := &MockKafkaSvc{}
 	run.Config.KafkaSvc = mockKafkaSvc
 
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	filePath := filepath.Join(homeDir, ".eureka", fmt.Sprintf(constant.CapabilitySetsFilePattern, "test-tenant"))
+	t.Cleanup(func() { _ = os.Remove(filePath) })
+
 	mockDocker.On("Create").Return(nil, nil)
 	mockModule.On("GetVaultRootToken", mock.Anything).Return("", nil)
 	mockKeycloak.On("GetMasterAccessToken", mock.AnythingOfType("constant.KeycloakGrantType")).Return("", nil)
@@ -1622,21 +1638,42 @@ func TestAttachCapabilitySets_Success(t *testing.T) {
 		Return([]any{map[string]any{"name": "test-tenant", "description": "nop-default"}}, nil)
 	mockKeycloak.On("UpdateRealmAccessTokenSettings", mock.Anything, mock.Anything).Return(nil)
 	mockKeycloak.On("GetAccessToken", mock.Anything).Return("", nil)
-	mockKeycloak.On("HasCapabilitySets", "test-tenant").Return(false, nil)
 	mockKafkaSvc.On("PollConsumerGroup", mock.Anything).Return(nil)
 	mockKeycloak.On("AttachCapabilitySetsToRoles", "test-tenant").Return(nil)
+	mockKeycloak.On("CountCapabilitySets", "test-tenant").Return(530, nil)
 
 	// Act
-	err := run.AttachCapabilitySets(constant.NoneConsortium, constant.Default, 0)
+	err = run.AttachCapabilitySets(constant.NoneConsortium, constant.Default, 0, false)
 
 	// Assert
 	assert.NoError(t, err)
 	mockKeycloak.AssertExpectations(t)
 	mockKafkaSvc.AssertExpectations(t)
+
+	var written capabilitySetsRecord
+	data, readErr := os.ReadFile(filePath)
+	if assert.NoError(t, readErr, "capability sets file should have been written") {
+		assert.NoError(t, json.Unmarshal(data, &written))
+		assert.Equal(t, "test-tenant", written.Tenant)
+		assert.Equal(t, 530, written.Total)
+	}
 }
 
-func TestAttachCapabilitySets_AlreadyExist_SkipsPoll(t *testing.T) {
-	// Arrange
+func TestAttachCapabilitySets_FilePersisted_SkipsPoll(t *testing.T) {
+	// Arrange — pre-create persistence file; live count matches → skip poll
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	filePath := filepath.Join(homeDir, ".eureka", fmt.Sprintf(constant.CapabilitySetsFilePattern, "test-tenant"))
+	if err := os.MkdirAll(filepath.Dir(filePath), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filePath, []byte(`{"tenant":"test-tenant","total":530}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Remove(filePath) })
+
 	run, mockManagement, mockKeycloak, _, mockDocker, mockModule := newTestRun(action.AttachCapabilitySets)
 	mockKafkaSvc := &MockKafkaSvc{}
 	run.Config.KafkaSvc = mockKafkaSvc
@@ -1648,16 +1685,24 @@ func TestAttachCapabilitySets_AlreadyExist_SkipsPoll(t *testing.T) {
 		Return([]any{map[string]any{"name": "test-tenant", "description": "nop-default"}}, nil)
 	mockKeycloak.On("UpdateRealmAccessTokenSettings", mock.Anything, mock.Anything).Return(nil)
 	mockKeycloak.On("GetAccessToken", mock.Anything).Return("", nil)
-	mockKeycloak.On("HasCapabilitySets", "test-tenant").Return(true, nil)
 	mockKeycloak.On("AttachCapabilitySetsToRoles", "test-tenant").Return(nil)
+	mockKeycloak.On("CountCapabilitySets", "test-tenant").Return(530, nil)
 
 	// Act
-	err := run.AttachCapabilitySets(constant.NoneConsortium, constant.Default, 0)
+	err = run.AttachCapabilitySets(constant.NoneConsortium, constant.Default, 0, false)
 
 	// Assert
 	assert.NoError(t, err)
 	mockKeycloak.AssertExpectations(t)
 	mockKafkaSvc.AssertNotCalled(t, "PollConsumerGroup", mock.Anything)
+
+	var written capabilitySetsRecord
+	data, readErr := os.ReadFile(filePath)
+	if assert.NoError(t, readErr, "capability sets file should still exist after re-attach") {
+		assert.NoError(t, json.Unmarshal(data, &written))
+		assert.Equal(t, "test-tenant", written.Tenant)
+		assert.Equal(t, 530, written.Total)
+	}
 }
 
 func TestAttachCapabilitySets_GetMasterTokenError(t *testing.T) {
@@ -1668,7 +1713,7 @@ func TestAttachCapabilitySets_GetMasterTokenError(t *testing.T) {
 	mockKeycloak.On("GetMasterAccessToken", mock.AnythingOfType("constant.KeycloakGrantType")).Return("", expectedError)
 
 	// Act
-	err := run.AttachCapabilitySets(constant.NoneConsortium, constant.Default, 0)
+	err := run.AttachCapabilitySets(constant.NoneConsortium, constant.Default, 0, false)
 
 	// Assert
 	assert.Error(t, err)
@@ -1690,7 +1735,7 @@ func TestAttachCapabilitySets_UpdateRealmError(t *testing.T) {
 	mockKeycloak.On("UpdateRealmAccessTokenSettings", mock.Anything, mock.Anything).Return(expectedError)
 
 	// Act
-	err := run.AttachCapabilitySets(constant.NoneConsortium, constant.Default, 0)
+	err := run.AttachCapabilitySets(constant.NoneConsortium, constant.Default, 0, false)
 
 	// Assert
 	assert.Error(t, err)
@@ -1712,17 +1757,183 @@ func TestAttachCapabilitySets_AttachError(t *testing.T) {
 		Return([]any{map[string]any{"name": "test-tenant", "description": "nop-default"}}, nil)
 	mockKeycloak.On("UpdateRealmAccessTokenSettings", mock.Anything, mock.Anything).Return(nil)
 	mockKeycloak.On("GetAccessToken", mock.Anything).Return("", nil)
-	mockKeycloak.On("HasCapabilitySets", "test-tenant").Return(false, nil)
 	mockKafkaSvc.On("PollConsumerGroup", mock.Anything).Return(nil)
 	mockKeycloak.On("AttachCapabilitySetsToRoles", "test-tenant").Return(expectedError)
 
 	// Act
-	err := run.AttachCapabilitySets(constant.NoneConsortium, constant.Default, 0)
+	err := run.AttachCapabilitySets(constant.NoneConsortium, constant.Default, 0, false)
 
 	// Assert
 	assert.Error(t, err)
 	assert.Equal(t, expectedError, err)
 	mockKeycloak.AssertExpectations(t)
+	mockKeycloak.AssertNotCalled(t, "CountCapabilitySets", mock.Anything)
+}
+
+func TestAttachCapabilitySets_ForceRefresh_DeletesFile(t *testing.T) {
+	// Arrange — pre-create file; forceRefresh=true deletes it, forcing a full poll
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	filePath := filepath.Join(homeDir, ".eureka", fmt.Sprintf(constant.CapabilitySetsFilePattern, "test-tenant"))
+	if err := os.MkdirAll(filepath.Dir(filePath), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filePath, []byte(`{"tenant":"test-tenant","total":200}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Remove(filePath) })
+
+	run, mockManagement, mockKeycloak, _, mockDocker, mockModule := newTestRun(action.AttachCapabilitySets)
+	mockKafkaSvc := &MockKafkaSvc{}
+	run.Config.KafkaSvc = mockKafkaSvc
+
+	mockDocker.On("Create").Return(nil, nil)
+	mockModule.On("GetVaultRootToken", mock.Anything).Return("", nil)
+	mockKeycloak.On("GetMasterAccessToken", mock.AnythingOfType("constant.KeycloakGrantType")).Return("", nil)
+	mockManagement.On("GetTenants", mock.Anything, mock.Anything).
+		Return([]any{map[string]any{"name": "test-tenant", "description": "nop-default"}}, nil)
+	mockKeycloak.On("UpdateRealmAccessTokenSettings", mock.Anything, mock.Anything).Return(nil)
+	mockKeycloak.On("GetAccessToken", mock.Anything).Return("", nil)
+	mockKafkaSvc.On("PollConsumerGroup", mock.Anything).Return(nil)
+	mockKeycloak.On("AttachCapabilitySetsToRoles", "test-tenant").Return(nil)
+	mockKeycloak.On("CountCapabilitySets", "test-tenant").Return(200, nil)
+
+	// Act
+	err = run.AttachCapabilitySets(constant.NoneConsortium, constant.Default, 0, true)
+
+	// Assert — poll must have been called since file was deleted
+	assert.NoError(t, err)
+	mockKafkaSvc.AssertExpectations(t)
+	mockKeycloak.AssertExpectations(t)
+
+	var written capabilitySetsRecord
+	data, readErr := os.ReadFile(filePath)
+	if assert.NoError(t, readErr, "capability sets file should have been re-written after force refresh") {
+		assert.NoError(t, json.Unmarshal(data, &written))
+		assert.Equal(t, 200, written.Total)
+	}
+}
+
+func TestAttachCapabilitySets_CountChanged_Polls(t *testing.T) {
+	// Arrange — persisted total doesn't match live count; poll is required
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	filePath := filepath.Join(homeDir, ".eureka", fmt.Sprintf(constant.CapabilitySetsFilePattern, "test-tenant"))
+	if err := os.MkdirAll(filepath.Dir(filePath), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filePath, []byte(`{"tenant":"test-tenant","total":100}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Remove(filePath) })
+
+	run, mockManagement, mockKeycloak, _, mockDocker, mockModule := newTestRun(action.AttachCapabilitySets)
+	mockKafkaSvc := &MockKafkaSvc{}
+	run.Config.KafkaSvc = mockKafkaSvc
+
+	mockDocker.On("Create").Return(nil, nil)
+	mockModule.On("GetVaultRootToken", mock.Anything).Return("", nil)
+	mockKeycloak.On("GetMasterAccessToken", mock.AnythingOfType("constant.KeycloakGrantType")).Return("", nil)
+	mockManagement.On("GetTenants", mock.Anything, mock.Anything).
+		Return([]any{map[string]any{"name": "test-tenant", "description": "nop-default"}}, nil)
+	mockKeycloak.On("UpdateRealmAccessTokenSettings", mock.Anything, mock.Anything).Return(nil)
+	mockKeycloak.On("GetAccessToken", mock.Anything).Return("", nil)
+	mockKafkaSvc.On("PollConsumerGroup", mock.Anything).Return(nil)
+	mockKeycloak.On("AttachCapabilitySetsToRoles", "test-tenant").Return(nil)
+	// pre-check returns 200 (≠ persisted 100); post-attach also returns 200
+	mockKeycloak.On("CountCapabilitySets", "test-tenant").Return(200, nil)
+
+	// Act
+	err = run.AttachCapabilitySets(constant.NoneConsortium, constant.Default, 0, false)
+
+	// Assert — poll called; file updated to live count
+	assert.NoError(t, err)
+	mockKafkaSvc.AssertExpectations(t)
+	mockKeycloak.AssertExpectations(t)
+
+	var written capabilitySetsRecord
+	data, readErr := os.ReadFile(filePath)
+	if assert.NoError(t, readErr, "capability sets file should have been updated to new count") {
+		assert.NoError(t, json.Unmarshal(data, &written))
+		assert.Equal(t, 200, written.Total)
+	}
+}
+
+func TestAttachCapabilitySets_PreCheckCountError_Polls(t *testing.T) {
+	// Arrange — CountCapabilitySets errors during pre-check; falls through to poll
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	filePath := filepath.Join(homeDir, ".eureka", fmt.Sprintf(constant.CapabilitySetsFilePattern, "test-tenant"))
+	if err := os.MkdirAll(filepath.Dir(filePath), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filePath, []byte(`{"tenant":"test-tenant","total":300}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Remove(filePath) })
+
+	run, mockManagement, mockKeycloak, _, mockDocker, mockModule := newTestRun(action.AttachCapabilitySets)
+	mockKafkaSvc := &MockKafkaSvc{}
+	run.Config.KafkaSvc = mockKafkaSvc
+
+	mockDocker.On("Create").Return(nil, nil)
+	mockModule.On("GetVaultRootToken", mock.Anything).Return("", nil)
+	mockKeycloak.On("GetMasterAccessToken", mock.AnythingOfType("constant.KeycloakGrantType")).Return("", nil)
+	mockManagement.On("GetTenants", mock.Anything, mock.Anything).
+		Return([]any{map[string]any{"name": "test-tenant", "description": "nop-default"}}, nil)
+	mockKeycloak.On("UpdateRealmAccessTokenSettings", mock.Anything, mock.Anything).Return(nil)
+	mockKeycloak.On("GetAccessToken", mock.Anything).Return("", nil)
+	mockKafkaSvc.On("PollConsumerGroup", mock.Anything).Return(nil)
+	mockKeycloak.On("AttachCapabilitySetsToRoles", "test-tenant").Return(nil)
+	mockKeycloak.On("CountCapabilitySets", "test-tenant").Return(0, assert.AnError).Once()
+	mockKeycloak.On("CountCapabilitySets", "test-tenant").Return(300, nil)
+
+	// Act
+	err = run.AttachCapabilitySets(constant.NoneConsortium, constant.Default, 0, false)
+
+	// Assert — poll called despite file existing; function succeeds
+	assert.NoError(t, err)
+	mockKafkaSvc.AssertExpectations(t)
+	mockKeycloak.AssertExpectations(t)
+}
+
+func TestAttachCapabilitySets_PostAttachCountError_ReturnsNil(t *testing.T) {
+	// Arrange — CountCapabilitySets errors after attach; non-fatal, function returns nil
+	run, mockManagement, mockKeycloak, _, mockDocker, mockModule := newTestRun(action.AttachCapabilitySets)
+	mockKafkaSvc := &MockKafkaSvc{}
+	run.Config.KafkaSvc = mockKafkaSvc
+
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	filePath := filepath.Join(homeDir, ".eureka", fmt.Sprintf(constant.CapabilitySetsFilePattern, "test-tenant"))
+	t.Cleanup(func() { _ = os.Remove(filePath) })
+
+	mockDocker.On("Create").Return(nil, nil)
+	mockModule.On("GetVaultRootToken", mock.Anything).Return("", nil)
+	mockKeycloak.On("GetMasterAccessToken", mock.AnythingOfType("constant.KeycloakGrantType")).Return("", nil)
+	mockManagement.On("GetTenants", mock.Anything, mock.Anything).
+		Return([]any{map[string]any{"name": "test-tenant", "description": "nop-default"}}, nil)
+	mockKeycloak.On("UpdateRealmAccessTokenSettings", mock.Anything, mock.Anything).Return(nil)
+	mockKeycloak.On("GetAccessToken", mock.Anything).Return("", nil)
+	mockKafkaSvc.On("PollConsumerGroup", mock.Anything).Return(nil)
+	mockKeycloak.On("AttachCapabilitySetsToRoles", "test-tenant").Return(nil)
+	mockKeycloak.On("CountCapabilitySets", "test-tenant").Return(0, assert.AnError)
+
+	// Act
+	err = run.AttachCapabilitySets(constant.NoneConsortium, constant.Default, 0, false)
+
+	// Assert — count error is non-fatal; no file written
+	assert.NoError(t, err)
+	_, statErr := os.Stat(filePath)
+	assert.True(t, os.IsNotExist(statErr), "capability sets file should not have been written after count error")
 }
 
 // ==================== DetachCapabilitySets Tests ====================

--- a/eureka-cli/cmd/deployApplication.go
+++ b/eureka-cli/cmd/deployApplication.go
@@ -102,7 +102,7 @@ func (run *Run) DeployApplication() error {
 		if err := run.CreateUsers(consortiumName, tenantType); err != nil {
 			return err
 		}
-		if err := run.AttachCapabilitySets(consortiumName, tenantType, constant.DeployApplicationPartitionWait); err != nil {
+		if err := run.AttachCapabilitySets(consortiumName, tenantType, constant.DeployApplicationPartitionWait, true); err != nil {
 			return err
 		}
 		if consortiumName != constant.NoneConsortium {
@@ -146,7 +146,7 @@ func (run *Run) DeployChildApplication() error {
 			return err
 		}
 
-		return run.AttachCapabilitySets(consortiumName, tenantType, 0*time.Second)
+		return run.AttachCapabilitySets(consortiumName, tenantType, 0*time.Second, true)
 	})
 }
 

--- a/eureka-cli/cmd/undeployApplication.go
+++ b/eureka-cli/cmd/undeployApplication.go
@@ -91,7 +91,7 @@ func (run *Run) UndeployChildApplication() error {
 			return err
 		}
 
-		return run.AttachCapabilitySets(consortiumName, tenantType, 0*time.Second)
+		return run.AttachCapabilitySets(consortiumName, tenantType, 0*time.Second, false)
 	})
 }
 

--- a/eureka-cli/config.combined-native-otel.yaml
+++ b/eureka-cli/config.combined-native-otel.yaml
@@ -192,14 +192,11 @@ backend-modules:
       cpus: 4
       memory: 900
   mod-login-keycloak:
-    # Versions >3.1.0-SNAPSHOT.156 are unusable, do not use until addressed 
-    version: 3.1.0-SNAPSHOT.156
     use-vault: true
     port: 9905
     environment:
       X_OKAPI_TOKEN_HEADER_ENABLED: "false"
       LOGIN_COOKIE_SAMESITE: "NONE"
-      KC_ADMIN_TOKEN_TTL: 895s
       KAFKA_PRODUCER_TENANT_COLLECTION: "true"
   mod-roles-keycloak:
     use-vault: true

--- a/eureka-cli/config.combined-native.yaml
+++ b/eureka-cli/config.combined-native.yaml
@@ -182,14 +182,11 @@ backend-modules:
       cpus: 4
       memory: 900
   mod-login-keycloak:
-    # Versions >3.1.0-SNAPSHOT.156 are unusable, do not use until addressed 
-    version: 3.1.0-SNAPSHOT.156
     use-vault: true
     port: 9905
     environment:
       X_OKAPI_TOKEN_HEADER_ENABLED: "false"
       LOGIN_COOKIE_SAMESITE: "NONE"
-      KC_ADMIN_TOKEN_TTL: 895s
       KAFKA_PRODUCER_TENANT_COLLECTION: "true"
   mod-roles-keycloak:
     use-vault: true

--- a/eureka-cli/config.combined.yaml
+++ b/eureka-cli/config.combined.yaml
@@ -178,14 +178,11 @@ backend-modules:
       cpus: 4
       memory: 900
   mod-login-keycloak:
-    # Versions >3.1.0-SNAPSHOT.156 are unusable, do not use until addressed 
-    version: 3.1.0-SNAPSHOT.156
     use-vault: true
     port: 9905
     environment:
       X_OKAPI_TOKEN_HEADER_ENABLED: "false"
       LOGIN_COOKIE_SAMESITE: "NONE"
-      KC_ADMIN_TOKEN_TTL: 895s
       KAFKA_PRODUCER_TENANT_COLLECTION: "true"
   mod-roles-keycloak:
     use-vault: true

--- a/eureka-cli/config.ecs-migration.yaml
+++ b/eureka-cli/config.ecs-migration.yaml
@@ -5611,14 +5611,11 @@ backend-modules:
       cpus: 4
       memory: 900
   mod-login-keycloak:
-    # Versions >3.1.0-SNAPSHOT.156 are unusable, do not use until addressed 
-    version: 3.1.0-SNAPSHOT.156
     use-vault: true
     port: 9905
     environment:
       X_OKAPI_TOKEN_HEADER_ENABLED: "false"
       LOGIN_COOKIE_SAMESITE: "NONE"
-      KC_ADMIN_TOKEN_TTL: 895s
       KAFKA_PRODUCER_TENANT_COLLECTION: "true"
   mod-roles-keycloak:
     use-vault: true

--- a/eureka-cli/config.ecs-single.yaml
+++ b/eureka-cli/config.ecs-single.yaml
@@ -232,14 +232,11 @@ backend-modules:
       cpus: 4
       memory: 900
   mod-login-keycloak:
-    # Versions >3.1.0-SNAPSHOT.156 are unusable, do not use until addressed 
-    version: 3.1.0-SNAPSHOT.156
     use-vault: true
     port: 9905
     environment:
       X_OKAPI_TOKEN_HEADER_ENABLED: "false"
       LOGIN_COOKIE_SAMESITE: "NONE"
-      KC_ADMIN_TOKEN_TTL: 895s
       KAFKA_PRODUCER_TENANT_COLLECTION: "true"
   mod-roles-keycloak:
     use-vault: true

--- a/eureka-cli/config.ecs.yaml
+++ b/eureka-cli/config.ecs.yaml
@@ -247,14 +247,11 @@ backend-modules:
       cpus: 4
       memory: 900
   mod-login-keycloak:
-    # Versions >3.1.0-SNAPSHOT.156 are unusable, do not use until addressed 
-    version: 3.1.0-SNAPSHOT.156
     use-vault: true
     port: 9905
     environment:
       X_OKAPI_TOKEN_HEADER_ENABLED: "false"
       LOGIN_COOKIE_SAMESITE: "NONE"
-      KC_ADMIN_TOKEN_TTL: 895s
       KAFKA_PRODUCER_TENANT_COLLECTION: "true"
   mod-roles-keycloak:
     use-vault: true

--- a/eureka-cli/config.import.yaml
+++ b/eureka-cli/config.import.yaml
@@ -191,14 +191,11 @@ backend-modules:
       cpus: 4
       memory: 900
   mod-login-keycloak:
-    # Versions >3.1.0-SNAPSHOT.156 are unusable, do not use until addressed 
-    version: 3.1.0-SNAPSHOT.156
     use-vault: true
     port: 9905
     environment:
       X_OKAPI_TOKEN_HEADER_ENABLED: "false"
       LOGIN_COOKIE_SAMESITE: "NONE"
-      KC_ADMIN_TOKEN_TTL: 895s
       KAFKA_PRODUCER_TENANT_COLLECTION: "true"
   mod-roles-keycloak:
     use-vault: true

--- a/eureka-cli/constant/constant.go
+++ b/eureka-cli/constant/constant.go
@@ -131,7 +131,8 @@ const (
 	EurekaRegistry = "eureka"
 
 	// Files
-	ModulesFile = "modules.json"
+	ModulesFile               = "modules.json"
+	CapabilitySetsFilePattern = "%s_capability_sets.json"
 
 	// Docker compose properties
 	DockerComposeWorkDir = "./misc"

--- a/eureka-cli/httpclient/http_client.go
+++ b/eureka-cli/httpclient/http_client.go
@@ -104,7 +104,9 @@ func (hc *HTTPClient) validateResponse(method, url string, httpResponse *http.Re
 	if httpResponse.StatusCode >= http.StatusOK && httpResponse.StatusCode < http.StatusMultipleChoices {
 		return nil
 	}
-	_ = helpers.DumpResponse(method, url, httpResponse, true)
+	if httpResponse.StatusCode != http.StatusNotFound {
+		_ = helpers.DumpResponse(method, url, httpResponse, true)
+	}
 
 	return errors.RequestFailed(httpResponse.StatusCode, httpResponse.Request.Method, httpResponse.Request.URL.String())
 }

--- a/eureka-cli/keycloaksvc/keycloak_svc_capability_set.go
+++ b/eureka-cli/keycloaksvc/keycloak_svc_capability_set.go
@@ -19,6 +19,7 @@ type KeycloakCapabilitySetManager interface {
 	GetCapabilitySets(headers map[string]string) ([]any, error)
 	GetCapabilitySetsByName(headers map[string]string, capabilityName string) ([]any, error)
 	HasCapabilitySets(tenantName string) (bool, error)
+	CountCapabilitySets(tenantName string) (int, error)
 	AttachCapabilitySetsToRoles(tenantName string) error
 	DetachCapabilitySetsFromRoles(tenantName string) error
 }
@@ -92,6 +93,19 @@ func (ks *KeycloakSvc) HasCapabilitySets(tenantName string) (bool, error) {
 		return false, err
 	}
 	return len(sets) > 0, nil
+}
+
+func (ks *KeycloakSvc) CountCapabilitySets(tenantName string) (int, error) {
+	headers, err := helpers.SecureOkapiTenantApplicationJSONHeaders(tenantName, ks.Action.KeycloakAccessToken)
+	if err != nil {
+		return 0, err
+	}
+	sets, err := ks.GetCapabilitySets(headers)
+	if err != nil {
+		return 0, err
+	}
+
+	return len(sets), nil
 }
 
 func (ks *KeycloakSvc) AttachCapabilitySetsToRoles(tenantName string) error {

--- a/eureka-cli/keycloaksvc/keycloak_svc_test.go
+++ b/eureka-cli/keycloaksvc/keycloak_svc_test.go
@@ -1778,6 +1778,94 @@ func TestHasCapabilitySets_GetCapabilitySetsError(t *testing.T) {
 	assert.False(t, has)
 }
 
+func TestCountCapabilitySets_ReturnsCount(t *testing.T) {
+	// Arrange
+	mockHTTP := &testhelpers.MockHTTPClient{}
+	act := testhelpers.NewMockAction()
+	act.KeycloakAccessToken = "token"
+	mockVault := &MockVaultClient{}
+	mockMgmt := &MockManagementSvc{}
+	svc := keycloaksvc.New(act, mockHTTP, mockVault, mockMgmt)
+
+	capSetsResponse := models.KeycloakCapabilitySetsResponse{
+		CapabilitySets: []models.KeycloakCapabilitySet{
+			{ID: "cap-1", Name: "users.read", ApplicationID: "app-1"},
+			{ID: "cap-2", Name: "users.write", ApplicationID: "app-1"},
+		},
+	}
+	mockMgmt.On("GetApplications").Return(models.ApplicationsResponse{ApplicationDescriptors: []map[string]any{{"id": "app-1"}}}, nil)
+	mockHTTP.On("GetRetryReturnStruct", mock.Anything, mock.Anything, mock.Anything).
+		Run(func(args mock.Arguments) {
+			*args.Get(2).(*models.KeycloakCapabilitySetsResponse) = capSetsResponse
+		}).
+		Return(nil)
+
+	// Act
+	count, err := svc.CountCapabilitySets("test-tenant")
+
+	// Assert
+	assert.NoError(t, err)
+	assert.Equal(t, 2, count)
+}
+
+func TestCountCapabilitySets_ReturnsZero_WhenEmpty(t *testing.T) {
+	// Arrange
+	mockHTTP := &testhelpers.MockHTTPClient{}
+	act := testhelpers.NewMockAction()
+	act.KeycloakAccessToken = "token"
+	mockVault := &MockVaultClient{}
+	mockMgmt := &MockManagementSvc{}
+	svc := keycloaksvc.New(act, mockHTTP, mockVault, mockMgmt)
+
+	mockMgmt.On("GetApplications").Return(models.ApplicationsResponse{ApplicationDescriptors: []map[string]any{{"id": "app-1"}}}, nil)
+	mockHTTP.On("GetRetryReturnStruct", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+
+	// Act
+	count, err := svc.CountCapabilitySets("test-tenant")
+
+	// Assert
+	assert.NoError(t, err)
+	assert.Equal(t, 0, count)
+}
+
+func TestCountCapabilitySets_HeadersError(t *testing.T) {
+	// Arrange
+	mockHTTP := &testhelpers.MockHTTPClient{}
+	act := testhelpers.NewMockAction()
+	// KeycloakAccessToken empty → headers error
+	mockVault := &MockVaultClient{}
+	mockMgmt := &MockManagementSvc{}
+	svc := keycloaksvc.New(act, mockHTTP, mockVault, mockMgmt)
+
+	// Act
+	count, err := svc.CountCapabilitySets("test-tenant")
+
+	// Assert
+	assert.Error(t, err)
+	assert.Equal(t, 0, count)
+}
+
+func TestCountCapabilitySets_GetCapabilitySetsError(t *testing.T) {
+	// Arrange
+	mockHTTP := &testhelpers.MockHTTPClient{}
+	act := testhelpers.NewMockAction()
+	act.KeycloakAccessToken = "token"
+	mockVault := &MockVaultClient{}
+	mockMgmt := &MockManagementSvc{}
+	svc := keycloaksvc.New(act, mockHTTP, mockVault, mockMgmt)
+
+	expectedError := errors.New("get applications failed")
+	mockMgmt.On("GetApplications").Return(models.ApplicationsResponse{}, expectedError)
+
+	// Act
+	count, err := svc.CountCapabilitySets("test-tenant")
+
+	// Assert
+	assert.Error(t, err)
+	assert.Equal(t, expectedError, err)
+	assert.Equal(t, 0, count)
+}
+
 func TestGetCapabilitySetsByName_Success(t *testing.T) {
 	// Arrange
 	mockHTTP := &testhelpers.MockHTTPClient{}


### PR DESCRIPTION
## Purpose

- <https://folio-org.atlassian.net/browse/ECLI-3>

## Approach

- Enhance git and http logging
- Improve idempotency, update configs

## Note about config

- There's now no descriptor behind this version of mod-login-keycloak
  - <https://folio-registry.dev.folio.org/_/proxy/modules/mod-login-keycloak-3.1.0-SNAPSHOT.156>