### PR TITLE
Add erm configuration with ERM, OA and Serials modules

### DIFF
--- a/eureka-cli/README.md
+++ b/eureka-cli/README.md
@@ -28,6 +28,7 @@
       - [Deploy the export application](#deploy-the-export-application)
       - [Deploy the search application](#deploy-the-search-application)
       - [Deploy the edge application](#deploy-the-edge-application)
+      - [Deploy the erm application](#deploy-the-erm-application)
     - [Undeploy child applications](#undeploy-child-applications)
     - [Intercept a module](#intercept-a-module)
     - [Create a port proxy](#create-a-port-proxy)
@@ -153,14 +154,14 @@ Available flags:
 
 **Global flags (available for all commands):**
 
-| Long                    | Short | Description                                                                                                                    |
-|-------------------------|-------|--------------------------------------------------------------------------------------------------------------------------------|
-| `--buildImages`         | `-b`  | Build Docker images                                                                                                            |
-| `--configFile`          | `-c`  | Specify config file path                                                                                                       |
-| `--enableDebug`         | `-d`  | Enable debug mode                                                                                                              |
-| `--onlyRequired`        | `-q`  | Use only required system containers (deploySystem, deployApplication)                                                          |
-| `--overwriteFiles`      | `-o`  | Overwrite files in .eureka home directory                                                                                      |
-| `--profile`             | `-p`  | Select profile (combined, combined-native, combined-native-otel, export, search, edge, ecs, ecs-single, ecs-migration, import) |
+| Long                    | Short | Description                                                                                                                         |
+|-------------------------|-------|-------------------------------------------------------------------------------------------------------------------------------------|
+| `--buildImages`         | `-b`  | Build Docker images                                                                                                                 |
+| `--configFile`          | `-c`  | Specify config file path                                                                                                            |
+| `--enableDebug`         | `-d`  | Enable debug mode                                                                                                                   |
+| `--onlyRequired`        | `-q`  | Use only required system containers (deploySystem, deployApplication)                                                               |
+| `--overwriteFiles`      | `-o`  | Overwrite files in .eureka home directory                                                                                           |
+| `--profile`             | `-p`  | Select profile (combined, combined-native, combined-native-otel, export, search, edge, erm, ecs, ecs-single, ecs-migration, import) |
 
 **Command-specific flags:**
 
@@ -234,7 +235,7 @@ eureka-cli deployApplication -q
 eureka-cli -p combined deployApplication
 ```
 
-> Available profiles are: _combined_, _combined-native_, _combined-native-otel_, _export_, _search_, _edge_, _ecs_, _ecs-single_, _ecs-migration_ and _import_ (_combined_, _combined-native_, _combined-native-otel_, _ecs_, _ecs-single_, _ecs-migration_ and _import_ are standalone applications).
+> Available profiles are: _combined_, _combined-native_, _combined-native-otel_, _export_, _search_, _edge_, _erm_, _ecs_, _ecs-single_, _ecs-migration_ and _import_ (_combined_, _combined-native_, _combined-native-otel_, _ecs_, _ecs-single_, _ecs-migration_ and _import_ are standalone applications).
 
 - It can be combined with the `-o` flag to overwrite all existing files in the `.eureka` home directory to receive changes from upstream
 
@@ -394,6 +395,16 @@ eureka-cli -p edge deployApplication
 
 ![CLI Deploy Edge Application](images/cli_deploy_edge_application.png)
 
+#### Deploy the erm application
+
+- The erm application contains modules, including mod-okapi-facade, for working with the ERM, OA and Serials
+
+```bash
+eureka-cli -p erm deployApplication
+```
+
+<!-- ![CLI Deploy ERM Application](images/cli_deploy_erm_application.png) -->
+
 ### Undeploy child applications
 
 - All child applications can be undeployed with the same `undeployApplication` command, which will remove both the modules and system containers used by the app
@@ -402,7 +413,7 @@ eureka-cli -p edge deployApplication
 eureka-cli -p {{profile}} undeployApplication
 ```
 
-> Replace `{{app}}` or `{{profile}}` with either of the supported child profiles: _export_, _search_ or _edge_.
+> Replace `{{app}}` or `{{profile}}` with either of the supported child profiles: _export_, _search_, _edge_ or _erm_.
 
 ### Intercept a module
 

--- a/eureka-cli/README.md
+++ b/eureka-cli/README.md
@@ -403,8 +403,6 @@ eureka-cli -p edge deployApplication
 eureka-cli -p erm deployApplication
 ```
 
-<!-- ![CLI Deploy ERM Application](images/cli_deploy_erm_application.png) -->
-
 ### Undeploy child applications
 
 - All child applications can be undeployed with the same `undeployApplication` command, which will remove both the modules and system containers used by the app

--- a/eureka-cli/config.erm.yaml
+++ b/eureka-cli/config.erm.yaml
@@ -1,0 +1,155 @@
+profile:
+  name: erm
+application:
+  name: app-erm
+  version: 1.0.0
+  fetch-descriptors: false
+  port-start: 35000
+  port-end: 35999
+  dependencies:
+    name: app-combined
+    version: 1.0.0
+lsp:
+  url: https://raw.githubusercontent.com/folio-org/platform-lsp/refs/heads/snapshot/platform-descriptor.json
+far:
+  url: https://far.ci.folio.org
+registry:
+  url: https://folio-registry.dev.folio.org
+environment:
+  # PostgreSQL
+  DB_HOST: postgres.eureka
+  DB_PORT: 5432
+  DB_DATABASE: folio
+  DB_USERNAME: folio_rw
+  DB_PASSWORD: supersecret
+  DB_CHARSET: UTF-8
+  DB_QUERYTIMEOUT: 60000
+  DB_MAXPOOLSIZE: 4
+  # Kafka
+  ENV: folio
+  KAFKA_HOST: kafka.eureka
+  KAFKA_PORT: 9092
+  KAFKA_PRODUCER_TENANT_COLLECTION: ALL
+  # Kong
+  KONG_ADMIN_URL: http://kong.eureka:8001
+  KONG_INTEGRATION_ENABLED: "true"
+  # Keycloak
+  KC_URL: http://keycloak.eureka:8080
+  KC_CONFIG_TTL: 3600s
+  KC_ADMIN_CLIENT_ID: folio-backend-admin-client
+  KC_ADMIN_CLIENT_SECRET: supersecret
+  KC_ADMIN_USERNAME: admin
+  KC_ADMIN_PASSWORD: admin
+  KC_IMPORT_ENABLED: "true"
+  KC_INTEGRATION_ENABLED: "true"
+  KC_LOGIN_CLIENT_SUFFIX: -application
+  KC_SERVICE_CLIENT_ID: sidecar-module-access-client
+  KC_URI_VALIDATION_ENABLED: "false"
+  SECURITY_ENABLED: "true"
+  OKAPI_INTEGRATION_ENABLED: "false"
+  WEB_CLIENT_TLS_VERIFY_HOSTNAME: "false"
+  # Java
+  JAVA_OPTIONS: >-
+    -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005 
+    -XX:MaxRAMPercentage=80.0 -Xms128m -Xmx400m 
+    -Djdk.internal.httpclient.disableHostnameVerification=true
+tenants:
+  diku:
+roles:
+  diku_admin_role:
+    tenant: diku
+    capability-sets: ["all"]
+sidecar-module:
+  # Must build locally for your OS and CPU
+  image: folio-module-sidecar-native
+  version: latest
+  custom-namespace: true
+  native-binary-cmd: [
+    "./application", "-Dquarkus.http.host=0.0.0.0", "-Dquarkus.log.category.'org.apache.kafka'.level=INFO"
+  ]
+  environment:
+    # Kafka
+    ENV: folio
+    KAFKA_HOST: kafka.eureka
+    KAFKA_PORT: 9092
+    # Keycloak
+    MOD_USERS_KEYCLOAK_URL: http://mod-users-keycloak-sc.eureka:8081
+    # Management
+    TM_CLIENT_URL: http://mgr-tenants.eureka:8081
+    AM_CLIENT_URL: http://mgr-applications.eureka:8081
+    TE_CLIENT_URL: http://mgr-tenant-entitlements.eureka:8081
+    # Sidecar
+    SIDECAR: "true"
+    SIDECAR_FORWARD_UNKNOWN_REQUESTS: "true"
+    SIDECAR_FORWARD_UNKNOWN_REQUESTS_DESTINATION: http://kong.eureka:8000
+    QUARKUS_HTTP_PORT: 8081
+    QUARKUS_REST_CLIENT_READ_TIMEOUT: 180000
+    QUARKUS_REST_CLIENT_CONNECT_TIMEOUT: 180000
+    QUARKUS_REST_CLIENT_SEND_TIMEOUT: 180000
+    QUARKUS_HTTP_LIMITS_MAX_INITIAL_LINE_LENGTH: 8192
+    SC_LOG_LEVEL: INFO
+    ROOT_LOG_LEVEL: INFO
+    REQUEST_TIMEOUT: 604800000
+    ALLOW_CROSS_TENANT_REQUESTS: "true"
+  resources:
+    cpus: 1
+    memory-reservation: 20
+    memory: 80
+backend-modules:
+  # ERM
+  mod-licenses:
+    private-port: 8080
+  mod-agreements:
+    private-port: 8080
+    resources:
+      memory: 2560
+    environment:
+      # uncomment to use PushKB (requires separate deployment) instead of Harvest
+      #INGRESS_TYPE: PushKB
+      JAVA_OPTIONS: >-
+        -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005
+        -XX:MaxRAMPercentage=80.0 -Xms256m -Xmx1792m
+        -Djdk.internal.httpclient.disableHostnameVerification=true
+  mod-okapi-facade:
+    environment:
+      TENANT_APPS_TTL: 600s
+      AM_TLS_ENABLED: "false"
+      TM_TLS_ENABLED: "false"
+      TE_TLS_ENABLED: "false"
+      AM_CLIENT_URL: http://mgr-applications.eureka:8081
+      MT_CLIENT_URL: http://mgr-tenants.eureka:8081
+      TE_URL: http://mgr-tenant-entitlements.eureka:8081
+  # eUsage
+  mod-erm-usage:
+  mod-erm-usage-harvester:
+    environment:
+      OKAPI_URL: http://mod-erm-usage-harvester-sc.eureka:8081
+  mod-eusage-reports:
+  # OA
+  mod-oa:
+    private-port: 8080
+  # Serials
+  mod-serials-management:
+    private-port: 8080
+frontend-modules:
+  # ACQ
+  folio_plugin-find-contact:
+  folio_plugin-find-interface:
+  folio_plugin-find-fund:
+  # ERM
+  folio_licenses:
+  folio_plugin-find-license:
+  folio_agreements:
+  folio_plugin-find-agreement:
+  folio_local-kb-admin:
+  folio_plugin-find-eresource:
+  folio_dashboard:
+  # eUsage
+  folio_plugin-eusage-reports:
+  folio_erm-comparisons:
+  folio_erm-usage:
+  folio_plugin-find-erm-usage-data-provider:
+  # OA
+  folio_oa:
+  # Serials
+  folio_serials-management:

--- a/eureka-cli/constant/constant.go
+++ b/eureka-cli/constant/constant.go
@@ -295,6 +295,7 @@ const (
 	ExportProfile             = "export"
 	SearchProfile             = "search"
 	EdgeProfile               = "edge"
+	ERMProfile                = "erm"
 	ECSProfile                = "ecs"
 	ECSSingleProfile          = "ecs-single"
 	ECSMigrationProfile       = "ecs-migration"
@@ -309,6 +310,7 @@ func GetProfiles() []string {
 		ExportProfile,
 		SearchProfile,
 		EdgeProfile,
+		ERMProfile,
 		ECSProfile,
 		ECSSingleProfile,
 		ECSMigrationProfile,

--- a/eureka-cli/constant/constant_test.go
+++ b/eureka-cli/constant/constant_test.go
@@ -135,7 +135,7 @@ func TestGetProfiles(t *testing.T) {
 	profiles := GetProfiles()
 
 	// Assert
-	assert.Len(t, profiles, 10)
+	assert.Len(t, profiles, 11)
 	assert.Contains(t, profiles, CombinedProfile)
 	assert.Contains(t, profiles, CombinedNativeProfile)
 	assert.Contains(t, profiles, CombinedNativeOtelProfile)

--- a/eureka-cli/constant/constant_test.go
+++ b/eureka-cli/constant/constant_test.go
@@ -142,6 +142,7 @@ func TestGetProfiles(t *testing.T) {
 	assert.Contains(t, profiles, ExportProfile)
 	assert.Contains(t, profiles, SearchProfile)
 	assert.Contains(t, profiles, EdgeProfile)
+	assert.Contains(t, profiles, ERMProfile)
 	assert.Contains(t, profiles, ECSProfile)
 	assert.Contains(t, profiles, ECSSingleProfile)
 	assert.Contains(t, profiles, ECSMigrationProfile)
@@ -159,10 +160,11 @@ func TestGetProfiles_OrderPreserved(t *testing.T) {
 	assert.Equal(t, ExportProfile, profiles[3])
 	assert.Equal(t, SearchProfile, profiles[4])
 	assert.Equal(t, EdgeProfile, profiles[5])
-	assert.Equal(t, ECSProfile, profiles[6])
-	assert.Equal(t, ECSSingleProfile, profiles[7])
-	assert.Equal(t, ECSMigrationProfile, profiles[8])
-	assert.Equal(t, ImportProfile, profiles[9])
+	assert.Equal(t, ERMProfile, profiles[6])
+	assert.Equal(t, ECSProfile, profiles[7])
+	assert.Equal(t, ECSSingleProfile, profiles[8])
+	assert.Equal(t, ECSMigrationProfile, profiles[9])
+	assert.Equal(t, ImportProfile, profiles[10])
 }
 
 // ==================== GetDefaultProfile Tests ====================
@@ -228,4 +230,5 @@ func TestProfileConstants(t *testing.T) {
 	assert.Equal(t, "ecs", ECSProfile)
 	assert.Equal(t, "ecs-single", ECSSingleProfile)
 	assert.Equal(t, "import", ImportProfile)
+	assert.Equal(t, "erm", ERMProfile)
 }

--- a/eureka-cli/misc/docker-compose.yaml
+++ b/eureka-cli/misc/docker-compose.yaml
@@ -72,7 +72,7 @@ services:
       "-c", "jit=off" 
     ]
     cpus: 2
-    mem_limit: 1536m
+    mem_limit: 2048m
     memswap_limit: -1
     shm_size: 768m
     environment:


### PR DESCRIPTION
This PR adds an erm configuration that includes all ERM modules and also the OA and Serials module. The README is also updated, but there is no screenshot yet.

Synchronizing larger packages from GOKB or working with COUNTER reports in eUsage requires more memory for postgres to work properly, therefore the memory limit for the postgres container is increased.