### PR TITLE
[ECLI-25-2]. Change sidecar implementation

### DIFF
--- a/eureka-cli/config.edge.yaml
+++ b/eureka-cli/config.edge.yaml
@@ -60,7 +60,13 @@ roles:
     tenant: diku
     capability-sets: ["all"]
 sidecar-module:
-  image: folio-module-sidecar
+  # Must build locally for your OS and CPU
+  image: folio-module-sidecar-native
+  version: latest
+  custom-namespace: true
+  native-binary-cmd: [
+    "./application", "-Dquarkus.http.host=0.0.0.0", "-Dquarkus.log.level=INFO"
+  ]
   environment:
     # Kafka
     ENV: folio
@@ -86,12 +92,10 @@ sidecar-module:
     ROOT_LOG_LEVEL: INFO
     REQUEST_TIMEOUT: 604800000
     ALLOW_CROSS_TENANT_REQUESTS: "true"
-    # Java
-    JAVA_OPTIONS: >-
-      -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005
-      -XX:+UseZGC -XX:MaxRAMPercentage=80.0 -Xms64m -Xmx64m
-      -Dquarkus.http.host=0.0.0.0 -Dquarkus.log.level=INFO
-      -Djava.util.logging.manager=org.jboss.logmanager.LogManager
+  resources:
+    cpus: 1
+    memory-reservation: 20
+    memory: 80
 backend-modules:
   mod-gobi:
   mod-ebsconet:

--- a/eureka-cli/config.export.yaml
+++ b/eureka-cli/config.export.yaml
@@ -60,7 +60,13 @@ roles:
     tenant: diku
     capability-sets: ["all"]
 sidecar-module:
-  image: folio-module-sidecar
+  # Must build locally for your OS and CPU
+  image: folio-module-sidecar-native
+  version: latest
+  custom-namespace: true
+  native-binary-cmd: [
+    "./application", "-Dquarkus.http.host=0.0.0.0", "-Dquarkus.log.level=INFO"
+  ]
   environment:
     # Kafka
     ENV: folio
@@ -86,12 +92,10 @@ sidecar-module:
     ROOT_LOG_LEVEL: INFO
     REQUEST_TIMEOUT: 604800000
     ALLOW_CROSS_TENANT_REQUESTS: "true"
-    # Java
-    JAVA_OPTIONS: >-
-      -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005
-      -XX:+UseZGC -XX:MaxRAMPercentage=80.0 -Xms64m -Xmx64m
-      -Dquarkus.http.host=0.0.0.0 -Dquarkus.log.level=INFO
-      -Djava.util.logging.manager=org.jboss.logmanager.LogManager
+  resources:
+    cpus: 1
+    memory-reservation: 20
+    memory: 80
 backend-modules:
   mod-data-export-spring:
     use-okapi-url: true

--- a/eureka-cli/config.search.yaml
+++ b/eureka-cli/config.search.yaml
@@ -60,7 +60,13 @@ roles:
     tenant: diku
     capability-sets: ["all"]
 sidecar-module:
-  image: folio-module-sidecar
+  # Must build locally for your OS and CPU
+  image: folio-module-sidecar-native
+  version: latest
+  custom-namespace: true
+  native-binary-cmd: [
+    "./application", "-Dquarkus.http.host=0.0.0.0", "-Dquarkus.log.level=INFO"
+  ]
   environment:
     # Kafka
     ENV: folio
@@ -86,12 +92,10 @@ sidecar-module:
     ROOT_LOG_LEVEL: INFO
     REQUEST_TIMEOUT: 604800000
     ALLOW_CROSS_TENANT_REQUESTS: "true"
-    # Java
-    JAVA_OPTIONS: >-
-      -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005
-      -XX:+UseZGC -XX:MaxRAMPercentage=80.0 -Xms64m -Xmx64m
-      -Dquarkus.http.host=0.0.0.0 -Dquarkus.log.level=INFO
-      -Djava.util.logging.manager=org.jboss.logmanager.LogManager
+  resources:
+    cpus: 1
+    memory-reservation: 20
+    memory: 80
 backend-modules:
   mod-search:
     use-okapi-url: true

--- a/eureka-cli/docs/ERM_PROFILE_SETUP_GUIDE.md
+++ b/eureka-cli/docs/ERM_PROFILE_SETUP_GUIDE.md
@@ -1,0 +1,79 @@
+# ERM Profile Setup Guide
+
+## Purpose
+
+- Support commands to deploy a local dev environment with combined and ERM applications
+
+## Commands
+
+### Deploy applications with Eureka CLI
+
+- Deploy the parent application with ACQ modules
+
+```bash
+eureka-cli deployApplication -p combined-native -oq
+```
+
+> Check README.md in eureka-cli/ folder for how to build the local native sidecar Docker image
+
+- Deploy the child application with ERM modules
+
+```bash
+eureka-cli deployApplication -p erm -oq
+```
+
+### Clone, prepare and intercept ERM modules with Eureka CLI
+
+- Git clone each module into a folder, e.g. `~/Folio/erm-modules`
+
+```bash
+cd ~/Folio/erm-modules/
+git clone git@github.com:folio-org/mod-agreements.git
+git clone git@github.com:folio-org/mod-licenses.git
+git clone git@github.com:folio-org/mod-oa.git
+git clone git@github.com:folio-org/mod-serials-management.git
+```
+
+- Change branch to `thunderjet-erm`
+
+```bash
+cd ~/Folio/erm-modules/mod-agreements && git checkout thunderjet-erm
+cd ~/Folio/erm-modules/mod-licenses && git checkout thunderjet-erm
+cd ~/Folio/erm-modules/mod-oa && git checkout thunderjet-erm
+cd ~/Folio/erm-modules/mod-serials-management && git checkout thunderjet-erm
+```
+
+- Open erm-modules as a folder with IntelliJ, and import each module with Gradle
+
+> Set JDK either to Java 17 or 19
+
+- Run each module in IntelliJ with the supplied run configurations found in `run-configs/`
+
+> The first few minutes are necessary for the module to boot up
+
+- Run module interception with the CLI
+
+```bash
+eureka-cli -p erm interceptModule -n mod-agreements -g -m 36105 -s 37105
+eureka-cli -p erm interceptModule -n mod-licenses -g -m 36106 -s 37106
+eureka-cli -p erm interceptModule -n mod-oa -g -m 36107 -s 37107
+eureka-cli -p erm interceptModule -n mod-serials-management -g -m 36108 -s 37108
+```
+
+- When the interception is no longer required, disable it for each module to prevent deadlocking on application undeployment
+
+```bash
+eureka-cli -p erm interceptModule -n mod-agreements -r
+eureka-cli -p erm interceptModule -n mod-licenses -r
+eureka-cli -p erm interceptModule -n mod-oa -r
+eureka-cli -p erm interceptModule -n mod-serials-management -r
+```
+
+> ERM application cannot be undeployed unless the interception is disabled
+
+### Undeploy all application
+
+```bash
+eureka-cli undeployApplication -p erm
+eureka-cli undeployApplication -p combined-native
+```

--- a/eureka-cli/docs/run-configs/[mod-agreements] Run.run.xml
+++ b/eureka-cli/docs/run-configs/[mod-agreements] Run.run.xml
@@ -1,0 +1,43 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="[mod-agreements] Run" type="GradleRunConfiguration" factoryName="Gradle">
+    <ExternalSystemSettings>
+      <option name="env">
+        <map>
+          <entry key="CONCURRENT_JOBS_GLOBAL" value="1" />
+          <entry key="DB_CHARSET" value="UTF-8" />
+          <entry key="DB_DATABASE" value="folio" />
+          <entry key="DB_HOST" value="localhost" />
+          <entry key="DB_MAXPOOLSIZE" value="15" />
+          <entry key="DB_PASSWORD" value="supersecret" />
+          <entry key="DB_PORT" value="5432" />
+          <entry key="DB_QUERYTIMEOUT" value="60000" />
+          <entry key="DB_USERNAME" value="folio_rw" />
+          <entry key="OKAPI_SERVICE_HOST" value="localhost" />
+          <entry key="OKAPI_SERVICE_PORT" value="37105" />
+        </map>
+      </option>
+      <option name="executionName" />
+      <option name="externalProjectPath" value="$PROJECT_DIR$/mod-agreements/service" />
+      <option name="externalSystemIdString" value="GRADLE" />
+      <option name="scriptParameters" value="" />
+      <option name="taskDescriptions">
+        <list />
+      </option>
+      <option name="taskNames">
+        <list>
+          <option value="bootRun" />
+          <option value="--args='--server.port=36105'" />
+        </list>
+      </option>
+      <option name="vmOptions" value="-Xms128m -Xmx768m" />
+    </ExternalSystemSettings>
+    <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>
+    <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+    <ExternalSystemDebugDisabled>false</ExternalSystemDebugDisabled>
+    <DebugAllEnabled>false</DebugAllEnabled>
+    <RunAsTest>false</RunAsTest>
+    <GradleProfilingDisabled>false</GradleProfilingDisabled>
+    <GradleCoverageDisabled>false</GradleCoverageDisabled>
+    <method v="2" />
+  </configuration>
+</component>

--- a/eureka-cli/docs/run-configs/[mod-licenses] Run.run.xml
+++ b/eureka-cli/docs/run-configs/[mod-licenses] Run.run.xml
@@ -1,0 +1,42 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="[mod-licenses] Run" type="GradleRunConfiguration" factoryName="Gradle">
+    <ExternalSystemSettings>
+      <option name="env">
+        <map>
+          <entry key="DB_CHARSET" value="UTF-8" />
+          <entry key="DB_DATABASE" value="folio" />
+          <entry key="DB_HOST" value="localhost" />
+          <entry key="DB_MAXPOOLSIZE" value="15" />
+          <entry key="DB_PASSWORD" value="supersecret" />
+          <entry key="DB_PORT" value="5432" />
+          <entry key="DB_QUERYTIMEOUT" value="60000" />
+          <entry key="DB_USERNAME" value="folio_rw" />
+          <entry key="OKAPI_SERVICE_HOST" value="localhost" />
+          <entry key="OKAPI_SERVICE_PORT" value="37106" />
+        </map>
+      </option>
+      <option name="executionName" />
+      <option name="externalProjectPath" value="$PROJECT_DIR$/mod-licenses/service" />
+      <option name="externalSystemIdString" value="GRADLE" />
+      <option name="scriptParameters" value="" />
+      <option name="taskDescriptions">
+        <list />
+      </option>
+      <option name="taskNames">
+        <list>
+          <option value="bootRun" />
+          <option value="--args='--server.port=36106'" />
+        </list>
+      </option>
+      <option name="vmOptions" value="-Xms128m -Xmx768m" />
+    </ExternalSystemSettings>
+    <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>
+    <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+    <ExternalSystemDebugDisabled>false</ExternalSystemDebugDisabled>
+    <DebugAllEnabled>false</DebugAllEnabled>
+    <RunAsTest>false</RunAsTest>
+    <GradleProfilingDisabled>false</GradleProfilingDisabled>
+    <GradleCoverageDisabled>false</GradleCoverageDisabled>
+    <method v="2" />
+  </configuration>
+</component>

--- a/eureka-cli/docs/run-configs/[mod-oa] Run.run.xml
+++ b/eureka-cli/docs/run-configs/[mod-oa] Run.run.xml
@@ -1,0 +1,42 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="[mod-oa] Run" type="GradleRunConfiguration" factoryName="Gradle">
+    <ExternalSystemSettings>
+      <option name="env">
+        <map>
+          <entry key="DB_CHARSET" value="UTF-8" />
+          <entry key="DB_DATABASE" value="folio" />
+          <entry key="DB_HOST" value="localhost" />
+          <entry key="DB_MAXPOOLSIZE" value="15" />
+          <entry key="DB_PASSWORD" value="supersecret" />
+          <entry key="DB_PORT" value="5432" />
+          <entry key="DB_QUERYTIMEOUT" value="60000" />
+          <entry key="DB_USERNAME" value="folio_rw" />
+          <entry key="OKAPI_SERVICE_HOST" value="localhost" />
+          <entry key="OKAPI_SERVICE_PORT" value="37107" />
+        </map>
+      </option>
+      <option name="executionName" />
+      <option name="externalProjectPath" value="$PROJECT_DIR$/mod-oa/service" />
+      <option name="externalSystemIdString" value="GRADLE" />
+      <option name="scriptParameters" value="" />
+      <option name="taskDescriptions">
+        <list />
+      </option>
+      <option name="taskNames">
+        <list>
+          <option value="bootRun" />
+          <option value="--args='--server.port=36107'" />
+        </list>
+      </option>
+      <option name="vmOptions" value="-Xms128m -Xmx768m" />
+    </ExternalSystemSettings>
+    <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>
+    <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+    <ExternalSystemDebugDisabled>false</ExternalSystemDebugDisabled>
+    <DebugAllEnabled>false</DebugAllEnabled>
+    <RunAsTest>false</RunAsTest>
+    <GradleProfilingDisabled>false</GradleProfilingDisabled>
+    <GradleCoverageDisabled>false</GradleCoverageDisabled>
+    <method v="2" />
+  </configuration>
+</component>

--- a/eureka-cli/docs/run-configs/[mod-serials-management] Run.run.xml
+++ b/eureka-cli/docs/run-configs/[mod-serials-management] Run.run.xml
@@ -1,0 +1,43 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="[mod-serials-management] Run" type="GradleRunConfiguration" factoryName="Gradle">
+    <ExternalSystemSettings>
+      <option name="env">
+        <map>
+          <entry key="DB_CHARSET" value="UTF-8" />
+          <entry key="DB_DATABASE" value="folio" />
+          <entry key="DB_HOST" value="localhost" />
+          <entry key="DB_MAXPOOLSIZE" value="15" />
+          <entry key="DB_PASSWORD" value="supersecret" />
+          <entry key="DB_PORT" value="5432" />
+          <entry key="DB_QUERYTIMEOUT" value="60000" />
+          <entry key="DB_USERNAME" value="folio_rw" />
+          <entry key="OKAPI_SERVICE_HOST" value="localhost" />
+          <entry key="OKAPI_SERVICE_PORT" value="37108" />
+        </map>
+      </option>
+      <option name="executionName" />
+      <option name="externalProjectPath" value="$PROJECT_DIR$/mod-serials-management/service" />
+      <option name="externalSystemIdString" value="GRADLE" />
+      <option name="scriptParameters" value="" />
+      <option name="taskDescriptions">
+        <list />
+      </option>
+      <option name="taskNames">
+        <list>
+          <option value="bootRun" />
+          <option value="--args='--server.port=36108'" />
+        </list>
+      </option>
+      <option name="vmOptions" value="-Xms128m -Xmx768m" />
+    </ExternalSystemSettings>
+    <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>
+    <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+    <ExternalSystemDebugDisabled>false</ExternalSystemDebugDisabled>
+    <DebugAllEnabled>false</DebugAllEnabled>
+    <RunAsTest>false</RunAsTest>
+    <GradleProfilingDisabled>false</GradleProfilingDisabled>
+    <GradleCoverageDisabled>false</GradleCoverageDisabled>
+    <method v="2" />
+  </configuration>
+</component>
+


### PR DESCRIPTION
## Purpose


## Approach

- Change the sidecar implementation for each of the remaining child app from the invalid JVM sidecar to native custom-built (JVM-based sidecar downloaded from the Docker Hub are built with an invalid entrypoint)
- Add `ERM_PROFILE_SETUP_GUIDE.md` and IntelliJ `run-config/` to `docs/`
