### PR TITLE
Update dependabot interval

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
   - package-ecosystem: "gomod"
     directory: "/eureka-cli"
     schedule:
-      interval: weekly
+      interval: "monthly"
     open-pull-requests-limit: 3
     commit-message:
       prefix: "chore(deps)"
@@ -19,7 +19,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     open-pull-requests-limit: 2
     commit-message:
       prefix: "chore(actions)"

--- a/eureka-cli/README.md
+++ b/eureka-cli/README.md
@@ -89,6 +89,8 @@ Configure hosts (add entries to `/etc/hosts` or `C:\Windows\System32\drivers\etc
   - `127.0.0.1 keycloak.eureka`
   - `127.0.0.1 kong.eureka`
 
+> **WARNING:** JVM sidecar images published on FOLIO Docker Hub are built with an invalid entrypoint and will fail to start. If you intend to use sidecars, you must build a native sidecar image locally — see [Using a native folio-module-sidecar](#using-a-native-folio-module-sidecar).
+
 ## Monitor system components
 
 - [Dozzle](http://localhost:8888) UI: No auth
@@ -671,7 +673,7 @@ sidecar-module:
   ]
 ```
 
-> The `version` must be set explicitly.
+> The `version` must be set explicitly. If the `sidecar-module` block is already configured for your profile, then disregard this last step.
 
 - Deploy the environment using the _combined-native_ profile that already has `JAVA_OPTIONS` env var removed from the `sidecar-module` in the config, as this is not interpreted by the substrate VM in the image
 

--- a/eureka-cli/config.import.yaml
+++ b/eureka-cli/config.import.yaml
@@ -89,7 +89,13 @@ users:
     last-name: User
     roles: ["diku_user_role"]
 sidecar-module:
-  image: folio-module-sidecar
+  # Must build locally for your OS and CPU
+  image: folio-module-sidecar-native
+  version: latest
+  custom-namespace: true
+  native-binary-cmd: [
+    "./application", "-Dquarkus.http.host=0.0.0.0", "-Dquarkus.log.level=INFO"
+  ]
   environment:
     # Kafka
     ENV: folio
@@ -115,12 +121,10 @@ sidecar-module:
     ROOT_LOG_LEVEL: INFO
     REQUEST_TIMEOUT: 604800000
     ALLOW_CROSS_TENANT_REQUESTS: "true"
-    # Java
-    JAVA_OPTIONS: >-
-      -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005
-      -XX:+UseZGC -XX:MaxRAMPercentage=80.0 -Xms64m -Xmx64m
-      -Dquarkus.http.host=0.0.0.0 -Dquarkus.log.level=INFO
-      -Djava.util.logging.manager=org.jboss.logmanager.LogManager
+  resources:
+    cpus: 1
+    memory-reservation: 20
+    memory: 80
 backend-modules:
   mgr-applications:
     port: 9901

--- a/eureka-cli/docs/CLI_DEVELOPMENT_SETUP_GUIDE.md
+++ b/eureka-cli/docs/CLI_DEVELOPMENT_SETUP_GUIDE.md
@@ -111,3 +111,48 @@
 > Must undeploy previously deployed application before starting
 
 - The `args` can be modified to reflect which CLI command is to be debugged, e.g. `"args": ["createUsers", "-d"]` will run `createUsers` command in the debugged mode with verbose logs
+
+## Add new CLI command
+
+- To add a new CLI command install the latest versions of Cobra and Viper auxiliary CLIs
+
+```bash
+go get -u github.com/spf13/cobra@latest
+go get -u github.com/spf13/viper@lates
+```
+
+- After that you can create a new Eureka CLI command (also know as an **action**) with the Cobra CLI
+
+```bash
+cd eureka-cli
+cobra-cli add [my_new_command_name] --viper --author "Open Library Foundation" --license "Apache"
+```
+
+> The new command file will be created in the cmd/ package folder
+
+- Once created, register the new command action name in `action/action_name.go`
+- If the command receives arguments, register each new param in `action/action_param.go`
+
+## Update system components
+
+At the moment most system components, like _Keycloak_, _Kong_, and others, are not automatically updated, and must be regularly manually rebuilt and uploaded to keep up-to-date with the FOLIO development process.
+
+- Run the following set of commands to the rebuild and upload each system component manually to a specified Docker Hub registry namespace
+
+```bash
+cd eureka-cli
+docker build -t [my_namespace]/folio-netcat:latest ~/.eureka/misc/folio-netcat --no-cache
+docker build -t [my_namespace]/folio-vault:latest ~/.eureka/misc/folio-vault --no-cache
+docker build -t [my_namespace]/folio-kafka-tools:latest ~/.eureka/misc/folio-kafka-tools --no-cache
+docker build -t [my_namespace]/folio-keycloak:latest ~/.eureka/misc/folio-keycloak --no-cache
+docker build -t [my_namespace]/folio-kong:latest ~/.eureka/misc/folio-kong --no-cache
+
+docker push [my_namespace]/folio-netcat:latest
+docker push [my_namespace]/folio-vault:latest
+docker push [my_namespace]/folio-kafka-tools:latest
+docker push [my_namespace]/folio-keycloak:latest
+docker push [my_namespace]/folio-kong:latest
+```
+
+> The current registry namespace points to `bkadirkhodjaev`, but can be changed to use your own namspace once all file dependencies are updated
+


### PR DESCRIPTION
## Purpose

- Update dependabot interval

## Approach

- Set interval to `monthly` from `weekly`, to fire less frequently
- Update `import` profile to use the native sidecars (because the JVM sidecars are no longer valid for operation)
- Update root `README.md` and `docs/CLI_DEVELOPMENT_SETUP_GUIDE.md` with new information
