### PR TITLE
MODEXPW-625 - Enable use-okapi-url for mod-data-export-worker

### DIFF
--- a/eureka-cli/config.export.yaml
+++ b/eureka-cli/config.export.yaml
@@ -101,6 +101,7 @@ backend-modules:
     use-okapi-url: true
     disable-system-user: true
   mod-data-export-worker:
+    use-okapi-url: true
     environment:
       PLATFORM: eureka
       AWS_URL: http://minio.eureka:9000


### PR DESCRIPTION
[MODEXPW-625
](https://folio-org.atlassian.net/browse/MODEXPW-625)  - Send the export by email     

 ## Purpose
mod-data-export-worker's jobs are triggered over Kafka by mod-data-export-spring, which puts its **own** sidecar address into the `x-okapi-url` header. If the worker honors that URL, all of its outbound clients route through the wrong sidecar - one that does not declare the worker's routes and gives the calls the wrong module identity. In practice a call to `/template-request` then comes back as `404 "no Route matched"` (see folio-org/mod-data-export-worker#732 (comment)).
  
The worker fixes this in code: `buildFolioExecutionContext()` overwrites `x-okapi-url` with the worker's own sidecar via `folio.okapi-url` (e.g. `http://mod-data-export-worker-sc.eureka:8081`). For that override to resolve correctly in the Eureka stack, the deployment must inject the worker's own sidecar URL.
  
## Approach
 - Set `use-okapi-url: true` on the `mod-data-export-worker` module entry, so eureka-cli provides the worker its own sidecar `OKAPI_URL`. This mirrors the existing `mod-data-export-spring` entry and is the deployment-side counterpart to the worker code change in folio-org/mod-data-export-worker#732.

