### PR TITLE
Fix eureka config dir permissions

### DIFF
--- a/.github/workflows/build-and-run-cli.yml
+++ b/.github/workflows/build-and-run-cli.yml
@@ -63,11 +63,6 @@ jobs:
       - name: Setup Go Environment
         uses: ./.github/actions/setup-go
 
-      - name: Prepare .eureka config directory
-        run: |
-          mkdir -p /home/runner/.eureka
-          chmod -R 0700 /home/runner/.eureka
-
       - name: Run tests with coverage
         working-directory: ./eureka-cli
         run: |
@@ -94,18 +89,6 @@ jobs:
 
       - name: Setup Go Environment
         uses: ./.github/actions/setup-go
-
-      - name: Set up .eureka directory permissions
-        shell: bash
-        run: |
-          if [ "$RUNNER_OS" == "Windows" ]; then
-            mkdir -p "$USERPROFILE\.eureka"
-          else
-            mkdir -p "$HOME/.eureka"
-            chmod -R 0700 "$HOME/.eureka"
-          fi
-        env:
-          RUNNER_OS: ${{ runner.os }}
 
       - name: Build CLI
         working-directory: ./eureka-cli

--- a/eureka-cli/AGENTS.md
+++ b/eureka-cli/AGENTS.md
@@ -136,7 +136,8 @@ Pre-allocated slice with per-goroutine index — no mutex needed.
 - `stubLSP` / `stubFAR` helpers in `registrysvc/registry_svc_test.go` for LSP/FAR stubs
 - FAR module slices must be `[]any{map[string]any{...}, ...}` — not `[]map[string]any` — because `GetAnySlice` does `rawValue.([]any)`
 - `MockRegistrySvc` in `cmd/cmd_test.go` and `internal/testhelpers/mocks.go` must implement `RegistryProcessor` interface exactly: `GetModules(verbose bool, forceRefresh bool)`
-- Persistence tests write/read `~/modules.json` directly; use `t.Cleanup(func() { _ = os.Remove(filePath) })` — note the `_ =` to satisfy errcheck
+- Tests must never read from or write to a real directory such as `~/.eureka`. Any test whose code path resolves the home directory (`os.UserHomeDir`, `helpers.GetHomeDirPath`, `helpers.GetHomeMiscDir`) must call `testhelpers.SetTempHome(t)` first, which redirects `HOME`/`USERPROFILE` to a per-test temp directory
+- Persistence tests write/read `modules.json` under the temp home from `testhelpers.SetTempHome(t)`; use `t.Cleanup(func() { _ = os.Remove(filePath) })` — note the `_ =` to satisfy errcheck
 - Do NOT run `go test ./...` (RAM constrained) — target only affected packages
 - Run `golangci-lint run ./...` once as a finishing move, not after every edit
 

--- a/eureka-cli/cmd/cmd_test.go
+++ b/eureka-cli/cmd/cmd_test.go
@@ -1006,6 +1006,8 @@ func TestCloneUpdateRepositories_KeycloakRepoError(t *testing.T) {
 }
 
 func TestBuildSystem_Success(t *testing.T) {
+	testhelpers.SetTempHome(t)
+
 	// Arrange
 	run, _, _, _, _, _ := newTestRun(action.BuildSystem)
 	mockExecSvc := &MockExecSvc{}
@@ -1022,6 +1024,8 @@ func TestBuildSystem_Success(t *testing.T) {
 }
 
 func TestBuildSystem_Error(t *testing.T) {
+	testhelpers.SetTempHome(t)
+
 	// Arrange
 	run, _, _, _, _, _ := newTestRun(action.BuildSystem)
 	mockExecSvc := &MockExecSvc{}
@@ -1386,6 +1390,8 @@ func TestCreateFilter_SingleModule(t *testing.T) {
 // ==================== CheckPorts Tests ====================
 
 func TestCheckPorts_Success(t *testing.T) {
+	testhelpers.SetTempHome(t)
+
 	// Arrange
 	run, _, _, _, mockDocker, mockModule := newTestRun(action.CheckPorts)
 	mockExecSvc := &MockExecSvc{}
@@ -1405,6 +1411,8 @@ func TestCheckPorts_Success(t *testing.T) {
 }
 
 func TestCheckPorts_ExecError(t *testing.T) {
+	testhelpers.SetTempHome(t)
+
 	// Arrange
 	run, _, _, _, _, _ := newTestRun(action.CheckPorts)
 	mockExecSvc := &MockExecSvc{}
@@ -1629,6 +1637,8 @@ func TestAttachCapabilitySets_Success(t *testing.T) {
 	mockKafkaSvc := &MockKafkaSvc{}
 	run.Config.KafkaSvc = mockKafkaSvc
 
+	testhelpers.SetTempHome(t)
+
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
 		t.Fatal(err)
@@ -1666,12 +1676,14 @@ func TestAttachCapabilitySets_Success(t *testing.T) {
 
 func TestAttachCapabilitySets_FilePersisted_SkipsPoll(t *testing.T) {
 	// Arrange — pre-create persistence file; live count matches → skip poll
+	testhelpers.SetTempHome(t)
+
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
 		t.Fatal(err)
 	}
 	filePath := filepath.Join(homeDir, ".eureka", fmt.Sprintf(constant.CapabilitySetsFilePattern, "test-tenant"))
-	if err := os.MkdirAll(filepath.Dir(filePath), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(filePath), constant.DirPerm); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(filePath, []byte(`{"tenant":"test-tenant","total":530}`), 0644); err != nil {
@@ -1749,6 +1761,8 @@ func TestAttachCapabilitySets_UpdateRealmError(t *testing.T) {
 }
 
 func TestAttachCapabilitySets_AttachError(t *testing.T) {
+	testhelpers.SetTempHome(t)
+
 	// Arrange
 	run, mockManagement, mockKeycloak, _, mockDocker, mockModule := newTestRun(action.AttachCapabilitySets)
 	mockKafkaSvc := &MockKafkaSvc{}
@@ -1777,12 +1791,14 @@ func TestAttachCapabilitySets_AttachError(t *testing.T) {
 
 func TestAttachCapabilitySets_ForceRefresh_DeletesFile(t *testing.T) {
 	// Arrange — pre-create file; forceRefresh=true deletes it, forcing a full poll
+	testhelpers.SetTempHome(t)
+
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
 		t.Fatal(err)
 	}
 	filePath := filepath.Join(homeDir, ".eureka", fmt.Sprintf(constant.CapabilitySetsFilePattern, "test-tenant"))
-	if err := os.MkdirAll(filepath.Dir(filePath), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(filePath), constant.DirPerm); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(filePath, []byte(`{"tenant":"test-tenant","total":200}`), 0644); err != nil {
@@ -1823,12 +1839,14 @@ func TestAttachCapabilitySets_ForceRefresh_DeletesFile(t *testing.T) {
 
 func TestAttachCapabilitySets_CountChanged_Polls(t *testing.T) {
 	// Arrange — persisted total doesn't match live count; poll is required
+	testhelpers.SetTempHome(t)
+
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
 		t.Fatal(err)
 	}
 	filePath := filepath.Join(homeDir, ".eureka", fmt.Sprintf(constant.CapabilitySetsFilePattern, "test-tenant"))
-	if err := os.MkdirAll(filepath.Dir(filePath), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(filePath), constant.DirPerm); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(filePath, []byte(`{"tenant":"test-tenant","total":100}`), 0644); err != nil {
@@ -1870,12 +1888,14 @@ func TestAttachCapabilitySets_CountChanged_Polls(t *testing.T) {
 
 func TestAttachCapabilitySets_PreCheckCountError_Polls(t *testing.T) {
 	// Arrange — CountCapabilitySets errors during pre-check; falls through to poll
+	testhelpers.SetTempHome(t)
+
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
 		t.Fatal(err)
 	}
 	filePath := filepath.Join(homeDir, ".eureka", fmt.Sprintf(constant.CapabilitySetsFilePattern, "test-tenant"))
-	if err := os.MkdirAll(filepath.Dir(filePath), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(filePath), constant.DirPerm); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(filePath, []byte(`{"tenant":"test-tenant","total":300}`), 0644); err != nil {
@@ -1913,6 +1933,8 @@ func TestAttachCapabilitySets_PostAttachCountError_ReturnsNil(t *testing.T) {
 	run, mockManagement, mockKeycloak, _, mockDocker, mockModule := newTestRun(action.AttachCapabilitySets)
 	mockKafkaSvc := &MockKafkaSvc{}
 	run.Config.KafkaSvc = mockKafkaSvc
+
+	testhelpers.SetTempHome(t)
 
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
@@ -2577,6 +2599,8 @@ func TestDeployModules_AllAlreadyDeployed_SkipsHealthcheck(t *testing.T) {
 }
 
 func TestDeploySystem_Success(t *testing.T) {
+	testhelpers.SetTempHome(t)
+
 	// Arrange
 	run, _, _, _, _, _ := newTestRun(action.DeploySystem)
 	mockGitClient := &testhelpers.MockGitClient{}
@@ -2599,6 +2623,8 @@ func TestDeploySystem_Success(t *testing.T) {
 }
 
 func TestDeploySystem_AlreadyRunning_SkipsSleep(t *testing.T) {
+	testhelpers.SetTempHome(t)
+
 	// Arrange
 	run, _, _, _, _, _ := newTestRun(action.DeploySystem)
 	mockGitClient := &testhelpers.MockGitClient{}
@@ -2623,6 +2649,8 @@ func TestDeploySystem_AlreadyRunning_SkipsSleep(t *testing.T) {
 }
 
 func TestDeploySystem_ExecError(t *testing.T) {
+	testhelpers.SetTempHome(t)
+
 	// Arrange
 	run, _, _, _, _, _ := newTestRun(action.DeploySystem)
 	mockGitClient := &testhelpers.MockGitClient{}
@@ -2663,6 +2691,8 @@ func TestDeployAdditionalSystem_NoContainers_Skips(t *testing.T) {
 }
 
 func TestDeployAdditionalSystem_NewContainers_Sleeps(t *testing.T) {
+	testhelpers.SetTempHome(t)
+
 	// Arrange
 	run, _, _, _, _, _ := newTestRun(action.DeployAdditionalSystem)
 	mockExecSvc := &MockExecSvc{}
@@ -2684,6 +2714,8 @@ func TestDeployAdditionalSystem_NewContainers_Sleeps(t *testing.T) {
 }
 
 func TestDeployAdditionalSystem_AlreadyRunning_SkipsSleep(t *testing.T) {
+	testhelpers.SetTempHome(t)
+
 	// Arrange
 	run, _, _, _, _, _ := newTestRun(action.DeployAdditionalSystem)
 	mockExecSvc := &MockExecSvc{}
@@ -2705,6 +2737,8 @@ func TestDeployAdditionalSystem_AlreadyRunning_SkipsSleep(t *testing.T) {
 }
 
 func TestDeployAdditionalSystem_ExecError(t *testing.T) {
+	testhelpers.SetTempHome(t)
+
 	// Arrange
 	run, _, _, _, _, _ := newTestRun(action.DeployAdditionalSystem)
 	mockExecSvc := &MockExecSvc{}

--- a/eureka-cli/cmd/root.go
+++ b/eureka-cli/cmd/root.go
@@ -97,13 +97,13 @@ func setDefaultLogger() (*slog.Logger, error) {
 		logLevel = slog.LevelDebug
 	}
 
-	home, err := os.UserHomeDir()
+	homeDir, err := helpers.GetHomeDirPath()
 	if err != nil {
 		return nil, err
 	}
 
-	logDir := filepath.Join(home, constant.ConfigDir, constant.LogDir)
-	if err := os.MkdirAll(logDir, 0755); err != nil {
+	logDir := filepath.Join(homeDir, constant.LogDir)
+	if err := os.MkdirAll(logDir, constant.DirPerm); err != nil {
 		return nil, err
 	}
 	timestamp := time.Now().Format(constant.LogTimestampFormat)

--- a/eureka-cli/constant/constant.go
+++ b/eureka-cli/constant/constant.go
@@ -1,6 +1,9 @@
 package constant
 
-import "time"
+import (
+	"os"
+	"time"
+)
 
 const (
 	// Command wait durations
@@ -121,6 +124,9 @@ const (
 	ConfigPrefix = "config"
 	ConfigDir    = ".eureka"
 	ConfigType   = "yaml"
+
+	// DirPerm is the mode for all directories created under the ~/.eureka config directory (owner-only)
+	DirPerm os.FileMode = 0700
 
 	// Logs
 	LogDir             = "logs"

--- a/eureka-cli/gitclient/git_client_test.go
+++ b/eureka-cli/gitclient/git_client_test.go
@@ -22,6 +22,8 @@ func TestNew(t *testing.T) {
 }
 
 func TestKongRepository(t *testing.T) {
+	testhelpers.SetTempHome(t)
+
 	// Arrange
 	action := testhelpers.NewMockAction()
 	client := New(action)
@@ -39,6 +41,8 @@ func TestKongRepository(t *testing.T) {
 }
 
 func TestKeycloakRepository(t *testing.T) {
+	testhelpers.SetTempHome(t)
+
 	// Arrange
 	action := testhelpers.NewMockAction()
 	client := New(action)
@@ -56,6 +60,8 @@ func TestKeycloakRepository(t *testing.T) {
 }
 
 func TestPlatformLspRepository_WithCustomBranch(t *testing.T) {
+	testhelpers.SetTempHome(t)
+
 	// Arrange
 	action := testhelpers.NewMockAction()
 	client := New(action)
@@ -74,6 +80,8 @@ func TestPlatformLspRepository_WithCustomBranch(t *testing.T) {
 }
 
 func TestPlatformLspRepository_WithDifferentBranch(t *testing.T) {
+	testhelpers.SetTempHome(t)
+
 	// Arrange
 	action := testhelpers.NewMockAction()
 	client := New(action)
@@ -92,6 +100,8 @@ func TestPlatformLspRepository_WithDifferentBranch(t *testing.T) {
 }
 
 func TestKongRepository_VerifyConstants(t *testing.T) {
+	testhelpers.SetTempHome(t)
+
 	// Arrange
 	action := testhelpers.NewMockAction()
 	client := New(action)
@@ -110,6 +120,8 @@ func TestKongRepository_VerifyConstants(t *testing.T) {
 }
 
 func TestKeycloakRepository_VerifyConstants(t *testing.T) {
+	testhelpers.SetTempHome(t)
+
 	// Arrange
 	action := testhelpers.NewMockAction()
 	client := New(action)
@@ -128,6 +140,8 @@ func TestKeycloakRepository_VerifyConstants(t *testing.T) {
 }
 
 func TestPlatformLspRepository_VerifyConstants(t *testing.T) {
+	testhelpers.SetTempHome(t)
+
 	// Arrange
 	action := testhelpers.NewMockAction()
 	client := New(action)
@@ -147,6 +161,8 @@ func TestPlatformLspRepository_VerifyConstants(t *testing.T) {
 }
 
 func TestKongRepository_UniqueFromKeycloak(t *testing.T) {
+	testhelpers.SetTempHome(t)
+
 	// Arrange
 	action := testhelpers.NewMockAction()
 	client := New(action)
@@ -166,6 +182,8 @@ func TestKongRepository_UniqueFromKeycloak(t *testing.T) {
 }
 
 func TestPlatformLspRepository_BranchParameter(t *testing.T) {
+	testhelpers.SetTempHome(t)
+
 	// Arrange
 	action := testhelpers.NewMockAction()
 	client := New(action)
@@ -193,6 +211,8 @@ func TestPlatformLspRepository_BranchParameter(t *testing.T) {
 }
 
 func TestRepositoryProvisioner_AllMethodsReturnGitRepository(t *testing.T) {
+	testhelpers.SetTempHome(t)
+
 	// Arrange
 	action := testhelpers.NewMockAction()
 	client := New(action)

--- a/eureka-cli/gitrepository/git_repository_test.go
+++ b/eureka-cli/gitrepository/git_repository_test.go
@@ -1,10 +1,12 @@
-package gitrepository
+package gitrepository_test
 
 import (
 	"path/filepath"
 	"testing"
 
 	"github.com/folio-org/eureka-setup/eureka-cli/action"
+	"github.com/folio-org/eureka-setup/eureka-cli/gitrepository"
+	"github.com/folio-org/eureka-setup/eureka-cli/internal/testhelpers"
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/stretchr/testify/assert"
 )
@@ -20,6 +22,8 @@ func newMockAction() *action.Action {
 }
 
 func TestNew_Success(t *testing.T) {
+	testhelpers.SetTempHome(t)
+
 	// Arrange
 	action := newMockAction()
 	label := "test-repo"
@@ -28,7 +32,7 @@ func TestNew_Success(t *testing.T) {
 	branch := plumbing.NewBranchReferenceName("main")
 
 	// Act
-	repo, err := New(action, label, url, dir, branch)
+	repo, err := gitrepository.New(action, label, url, dir, branch)
 
 	// Assert
 	assert.NoError(t, err)
@@ -40,6 +44,8 @@ func TestNew_Success(t *testing.T) {
 }
 
 func TestNew_WithDifferentBranch(t *testing.T) {
+	testhelpers.SetTempHome(t)
+
 	// Arrange
 	action := newMockAction()
 	label := "feature-repo"
@@ -48,7 +54,7 @@ func TestNew_WithDifferentBranch(t *testing.T) {
 	branch := plumbing.NewBranchReferenceName("feature-branch")
 
 	// Act
-	repo, err := New(action, label, url, dir, branch)
+	repo, err := gitrepository.New(action, label, url, dir, branch)
 
 	// Assert
 	assert.NoError(t, err)
@@ -60,6 +66,8 @@ func TestNew_WithDifferentBranch(t *testing.T) {
 }
 
 func TestNew_DirectoryPathConstruction(t *testing.T) {
+	testhelpers.SetTempHome(t)
+
 	// Arrange
 	action := newMockAction()
 	label := "path-test-repo"
@@ -68,7 +76,7 @@ func TestNew_DirectoryPathConstruction(t *testing.T) {
 	branch := plumbing.NewBranchReferenceName("develop")
 
 	// Act
-	repo, err := New(action, label, url, dir, branch)
+	repo, err := gitrepository.New(action, label, url, dir, branch)
 
 	// Assert
 	assert.NoError(t, err)
@@ -79,6 +87,8 @@ func TestNew_DirectoryPathConstruction(t *testing.T) {
 }
 
 func TestString_ReturnsLabel(t *testing.T) {
+	testhelpers.SetTempHome(t)
+
 	// Arrange
 	action := newMockAction()
 	label := "stringify-repo"
@@ -86,7 +96,7 @@ func TestString_ReturnsLabel(t *testing.T) {
 	dir := "stringify-dir"
 	branch := plumbing.NewBranchReferenceName("main")
 
-	repo, err := New(action, label, url, dir, branch)
+	repo, err := gitrepository.New(action, label, url, dir, branch)
 	assert.NoError(t, err)
 
 	// Act
@@ -97,6 +107,8 @@ func TestString_ReturnsLabel(t *testing.T) {
 }
 
 func TestNew_WithTagReference(t *testing.T) {
+	testhelpers.SetTempHome(t)
+
 	// Arrange
 	action := newMockAction()
 	label := "tag-repo"
@@ -105,7 +117,7 @@ func TestNew_WithTagReference(t *testing.T) {
 	branch := plumbing.NewTagReferenceName("v1.0.0")
 
 	// Act
-	repo, err := New(action, label, url, dir, branch)
+	repo, err := gitrepository.New(action, label, url, dir, branch)
 
 	// Assert
 	assert.NoError(t, err)
@@ -117,6 +129,8 @@ func TestNew_WithTagReference(t *testing.T) {
 }
 
 func TestNew_VerifyFieldValues(t *testing.T) {
+	testhelpers.SetTempHome(t)
+
 	// Arrange
 	action := newMockAction()
 	expectedLabel := "verify-repo"
@@ -125,7 +139,7 @@ func TestNew_VerifyFieldValues(t *testing.T) {
 	expectedBranch := plumbing.NewBranchReferenceName("snapshot")
 
 	// Act
-	repo, err := New(action, expectedLabel, expectedURL, expectedDir, expectedBranch)
+	repo, err := gitrepository.New(action, expectedLabel, expectedURL, expectedDir, expectedBranch)
 
 	// Assert
 	assert.NoError(t, err)
@@ -136,6 +150,8 @@ func TestNew_VerifyFieldValues(t *testing.T) {
 }
 
 func TestNew_EmptyValues(t *testing.T) {
+	testhelpers.SetTempHome(t)
+
 	// Arrange
 	action := newMockAction()
 	label := ""
@@ -144,7 +160,7 @@ func TestNew_EmptyValues(t *testing.T) {
 	branch := plumbing.ReferenceName("")
 
 	// Act
-	repo, err := New(action, label, url, dir, branch)
+	repo, err := gitrepository.New(action, label, url, dir, branch)
 
 	// Assert
 	assert.NoError(t, err)
@@ -155,6 +171,8 @@ func TestNew_EmptyValues(t *testing.T) {
 }
 
 func TestGitRepository_AllFieldsAccessible(t *testing.T) {
+	testhelpers.SetTempHome(t)
+
 	// Arrange
 	action := newMockAction()
 	label := "access-test"
@@ -163,7 +181,7 @@ func TestGitRepository_AllFieldsAccessible(t *testing.T) {
 	branch := plumbing.NewBranchReferenceName("master")
 
 	// Act
-	repo, err := New(action, label, url, dir, branch)
+	repo, err := gitrepository.New(action, label, url, dir, branch)
 
 	// Assert
 	assert.NoError(t, err)

--- a/eureka-cli/helpers/io_helper.go
+++ b/eureka-cli/helpers/io_helper.go
@@ -95,7 +95,7 @@ func CopyMultipleFiles(homeDir string, srcFs *embed.FS) error {
 
 		dstPath := filepath.Join(homeDir, path)
 		if dir.IsDir() {
-			if err := os.MkdirAll(dstPath, 0755); err != nil {
+			if err := os.MkdirAll(dstPath, constant.DirPerm); err != nil {
 				return err
 			}
 		} else {
@@ -152,7 +152,7 @@ func GetHomeDirPath() (string, error) {
 	}
 
 	homeDir := filepath.Join(userHome, constant.ConfigDir)
-	if err = os.MkdirAll(homeDir, 0700); err != nil {
+	if err = os.MkdirAll(homeDir, constant.DirPerm); err != nil {
 		return "", err
 	}
 

--- a/eureka-cli/helpers/io_helper.go
+++ b/eureka-cli/helpers/io_helper.go
@@ -156,6 +156,11 @@ func GetHomeDirPath() (string, error) {
 		return "", err
 	}
 
+	// MkdirAll does not change the mode of an existing directory, so repair installations created by older releases with wrong permissions
+	if err = os.Chmod(homeDir, constant.DirPerm); err != nil {
+		return "", err
+	}
+
 	return homeDir, nil
 }
 

--- a/eureka-cli/helpers/io_helper.go
+++ b/eureka-cli/helpers/io_helper.go
@@ -152,7 +152,7 @@ func GetHomeDirPath() (string, error) {
 	}
 
 	homeDir := filepath.Join(userHome, constant.ConfigDir)
-	if err = os.MkdirAll(homeDir, 0644); err != nil {
+	if err = os.MkdirAll(homeDir, 0700); err != nil {
 		return "", err
 	}
 

--- a/eureka-cli/helpers/io_helper_test.go
+++ b/eureka-cli/helpers/io_helper_test.go
@@ -4,6 +4,7 @@ import (
 	"embed"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/folio-org/eureka-setup/eureka-cli/helpers"
@@ -383,16 +384,35 @@ func TestGetCurrentWorkDirPath_Success(t *testing.T) {
 	assert.NotEmpty(t, result)
 }
 
-func TestGetHomeDirPath_Success(t *testing.T) {
+func TestGetHomeDirPath_CreatesDirectoryWithOwnerOnlyPermissions(t *testing.T) {
+	// Arrange
+	tempHome := t.TempDir()
+	t.Setenv("HOME", tempHome)
+	t.Setenv("USERPROFILE", tempHome)
+
 	// Act
 	result, err := helpers.GetHomeDirPath()
 
 	// Assert
 	assert.NoError(t, err)
-	assert.NotEmpty(t, result)
+	assert.Equal(t, filepath.Join(tempHome, ".eureka"), result)
+
+	info, statErr := os.Stat(result)
+	assert.NoError(t, statErr)
+	if assert.NotNil(t, info) {
+		assert.True(t, info.IsDir())
+		if runtime.GOOS != "windows" {
+			assert.Equal(t, os.FileMode(0700), info.Mode().Perm())
+		}
+	}
 }
 
 func TestGetHomeMiscDir_Success(t *testing.T) {
+	// Arrange
+	tempHome := t.TempDir()
+	t.Setenv("HOME", tempHome)
+	t.Setenv("USERPROFILE", tempHome)
+
 	// Act
 	result, err := helpers.GetHomeMiscDir()
 

--- a/eureka-cli/helpers/io_helper_test.go
+++ b/eureka-cli/helpers/io_helper_test.go
@@ -7,7 +7,9 @@ import (
 	"runtime"
 	"testing"
 
+	"github.com/folio-org/eureka-setup/eureka-cli/constant"
 	"github.com/folio-org/eureka-setup/eureka-cli/helpers"
+	"github.com/folio-org/eureka-setup/eureka-cli/internal/testhelpers"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -386,9 +388,7 @@ func TestGetCurrentWorkDirPath_Success(t *testing.T) {
 
 func TestGetHomeDirPath_CreatesDirectoryWithOwnerOnlyPermissions(t *testing.T) {
 	// Arrange
-	tempHome := t.TempDir()
-	t.Setenv("HOME", tempHome)
-	t.Setenv("USERPROFILE", tempHome)
+	tempHome := testhelpers.SetTempHome(t)
 
 	// Act
 	result, err := helpers.GetHomeDirPath()
@@ -402,16 +402,14 @@ func TestGetHomeDirPath_CreatesDirectoryWithOwnerOnlyPermissions(t *testing.T) {
 	if assert.NotNil(t, info) {
 		assert.True(t, info.IsDir())
 		if runtime.GOOS != "windows" {
-			assert.Equal(t, os.FileMode(0700), info.Mode().Perm())
+			assert.Equal(t, constant.DirPerm, info.Mode().Perm())
 		}
 	}
 }
 
 func TestGetHomeMiscDir_Success(t *testing.T) {
 	// Arrange
-	tempHome := t.TempDir()
-	t.Setenv("HOME", tempHome)
-	t.Setenv("USERPROFILE", tempHome)
+	testhelpers.SetTempHome(t)
 
 	// Act
 	result, err := helpers.GetHomeMiscDir()

--- a/eureka-cli/helpers/io_helper_test.go
+++ b/eureka-cli/helpers/io_helper_test.go
@@ -407,6 +407,26 @@ func TestGetHomeDirPath_CreatesDirectoryWithOwnerOnlyPermissions(t *testing.T) {
 	}
 }
 
+func TestGetHomeDirPath_RepairsExistingDirectoryPermissions(t *testing.T) {
+	// Arrange
+	tempHome := testhelpers.SetTempHome(t)
+	homeDir := filepath.Join(tempHome, ".eureka")
+	assert.NoError(t, os.Mkdir(homeDir, 0644))
+
+	// Act
+	result, err := helpers.GetHomeDirPath()
+
+	// Assert
+	assert.NoError(t, err)
+	assert.Equal(t, homeDir, result)
+
+	info, statErr := os.Stat(homeDir)
+	assert.NoError(t, statErr)
+	if runtime.GOOS != "windows" {
+		assert.Equal(t, constant.DirPerm, info.Mode().Perm())
+	}
+}
+
 func TestGetHomeMiscDir_Success(t *testing.T) {
 	// Arrange
 	testhelpers.SetTempHome(t)

--- a/eureka-cli/internal/testhelpers/file_helpers.go
+++ b/eureka-cli/internal/testhelpers/file_helpers.go
@@ -7,6 +7,17 @@ import (
 	"testing"
 )
 
+// SetTempHome redirects the user home directory to a per-test temporary directory so tests never touch the real ~/.eureka
+func SetTempHome(t *testing.T) string {
+	t.Helper()
+
+	tempHome := t.TempDir()
+	t.Setenv("HOME", tempHome)
+	t.Setenv("USERPROFILE", tempHome)
+
+	return tempHome
+}
+
 // CreateTempJSONFile creates a temporary JSON file with the given data
 func CreateTempJSONFile(t *testing.T, data any) string {
 	t.Helper()

--- a/eureka-cli/moduleprops/module_props_test.go
+++ b/eureka-cli/moduleprops/module_props_test.go
@@ -613,6 +613,10 @@ func TestReadBackendModules_Volumes(t *testing.T) {
 		}
 
 		// Arrange
+		tempHome := t.TempDir()
+		t.Setenv("HOME", tempHome)
+		t.Setenv("USERPROFILE", tempHome)
+
 		homeDir, err := helpers.GetHomeDirPath()
 		require.NoError(t, err)
 

--- a/eureka-cli/moduleprops/module_props_test.go
+++ b/eureka-cli/moduleprops/module_props_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/folio-org/eureka-setup/eureka-cli/action"
 	"github.com/folio-org/eureka-setup/eureka-cli/field"
 	"github.com/folio-org/eureka-setup/eureka-cli/helpers"
+	"github.com/folio-org/eureka-setup/eureka-cli/internal/testhelpers"
 	"github.com/folio-org/eureka-setup/eureka-cli/moduleprops"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -521,6 +522,8 @@ func TestReadBackendModules_LocalDescriptor(t *testing.T) {
 }
 
 func TestReadBackendModules_Volumes(t *testing.T) {
+	testhelpers.SetTempHome(t)
+
 	t.Run("TestReadBackendModules_Volumes_ValidVolume", func(t *testing.T) {
 		// Arrange
 		tmpDir := t.TempDir()
@@ -613,10 +616,6 @@ func TestReadBackendModules_Volumes(t *testing.T) {
 		}
 
 		// Arrange
-		tempHome := t.TempDir()
-		t.Setenv("HOME", tempHome)
-		t.Setenv("USERPROFILE", tempHome)
-
 		homeDir, err := helpers.GetHomeDirPath()
 		require.NoError(t, err)
 

--- a/eureka-cli/registrysvc/registry_svc_test.go
+++ b/eureka-cli/registrysvc/registry_svc_test.go
@@ -16,19 +16,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestMain redirects the user home directory to a temporary directory so tests never touch the real ~/.eureka
-func TestMain(m *testing.M) {
-	tempHome, err := os.MkdirTemp("", "eureka-test-home")
-	if err != nil {
-		panic(err)
-	}
-	_ = os.Setenv("HOME", tempHome)
-	_ = os.Setenv("USERPROFILE", tempHome)
-	code := m.Run()
-	_ = os.RemoveAll(tempHome)
-	os.Exit(code)
-}
-
 // MockAWSSvc is a mock for awssvc.AWSProcessor
 type MockAWSSvc struct {
 	mock.Mock
@@ -194,6 +181,8 @@ func stubFARWithUI(mockHTTP *testhelpers.MockHTTPClient, farBase string, appName
 }
 
 func TestGetModules_Success(t *testing.T) {
+	testhelpers.SetTempHome(t)
+
 	mockHTTP := &testhelpers.MockHTTPClient{}
 	mockAWS := &MockAWSSvc{}
 	act := testhelpers.NewMockAction()
@@ -221,6 +210,8 @@ func TestGetModules_Success(t *testing.T) {
 }
 
 func TestGetModules_Verbose(t *testing.T) {
+	testhelpers.SetTempHome(t)
+
 	mockHTTP := &testhelpers.MockHTTPClient{}
 	mockAWS := &MockAWSSvc{}
 	act := testhelpers.NewMockAction()
@@ -245,6 +236,8 @@ func TestGetModules_Verbose(t *testing.T) {
 }
 
 func TestGetModules_LSPFetchError(t *testing.T) {
+	testhelpers.SetTempHome(t)
+
 	mockHTTP := &testhelpers.MockHTTPClient{}
 	mockAWS := &MockAWSSvc{}
 	act := testhelpers.NewMockAction()
@@ -264,6 +257,8 @@ func TestGetModules_LSPFetchError(t *testing.T) {
 }
 
 func TestGetModules_FARFetchError(t *testing.T) {
+	testhelpers.SetTempHome(t)
+
 	mockHTTP := &testhelpers.MockHTTPClient{}
 	mockAWS := &MockAWSSvc{}
 	act := testhelpers.NewMockAction()
@@ -290,6 +285,8 @@ func TestGetModules_FARFetchError(t *testing.T) {
 }
 
 func TestGetModules_EurekaComponentsIncluded(t *testing.T) {
+	testhelpers.SetTempHome(t)
+
 	mockHTTP := &testhelpers.MockHTTPClient{}
 	mockAWS := &MockAWSSvc{}
 	act := testhelpers.NewMockAction()
@@ -312,6 +309,8 @@ func TestGetModules_EurekaComponentsIncluded(t *testing.T) {
 }
 
 func TestGetModules_ModulePartitioning(t *testing.T) {
+	testhelpers.SetTempHome(t)
+
 	mockHTTP := &testhelpers.MockHTTPClient{}
 	mockAWS := &MockAWSSvc{}
 	act := testhelpers.NewMockAction()
@@ -343,6 +342,8 @@ func TestGetModules_ModulePartitioning(t *testing.T) {
 }
 
 func TestGetModules_RequiredAndOptionalMerged(t *testing.T) {
+	testhelpers.SetTempHome(t)
+
 	mockHTTP := &testhelpers.MockHTTPClient{}
 	mockAWS := &MockAWSSvc{}
 	act := testhelpers.NewMockAction()
@@ -371,6 +372,8 @@ func TestGetModules_RequiredAndOptionalMerged(t *testing.T) {
 }
 
 func TestGetModules_ExperimentalAppsIncluded(t *testing.T) {
+	testhelpers.SetTempHome(t)
+
 	mockHTTP := &testhelpers.MockHTTPClient{}
 	mockAWS := &MockAWSSvc{}
 	act := testhelpers.NewMockAction()
@@ -402,6 +405,8 @@ func TestGetModules_ExperimentalAppsIncluded(t *testing.T) {
 }
 
 func TestGetModules_UIModulesIncluded(t *testing.T) {
+	testhelpers.SetTempHome(t)
+
 	mockHTTP := &testhelpers.MockHTTPClient{}
 	mockAWS := &MockAWSSvc{}
 	act := testhelpers.NewMockAction()
@@ -433,6 +438,8 @@ func TestGetModules_UIModulesIncluded(t *testing.T) {
 }
 
 func TestGetModules_EmptyApplications(t *testing.T) {
+	testhelpers.SetTempHome(t)
+
 	mockHTTP := &testhelpers.MockHTTPClient{}
 	mockAWS := &MockAWSSvc{}
 	act := testhelpers.NewMockAction()
@@ -456,6 +463,8 @@ func TestGetModules_EmptyApplications(t *testing.T) {
 // ==================== isEurekaModule Tests ====================
 
 func TestIsEurekaModule_KeycloakSuffix(t *testing.T) {
+	testhelpers.SetTempHome(t)
+
 	mockHTTP := &testhelpers.MockHTTPClient{}
 	mockAWS := &MockAWSSvc{}
 	act := testhelpers.NewMockAction()
@@ -479,6 +488,8 @@ func TestIsEurekaModule_KeycloakSuffix(t *testing.T) {
 }
 
 func TestIsEurekaModule_MgrPrefix(t *testing.T) {
+	testhelpers.SetTempHome(t)
+
 	mockHTTP := &testhelpers.MockHTTPClient{}
 	mockAWS := &MockAWSSvc{}
 	act := testhelpers.NewMockAction()
@@ -503,6 +514,8 @@ func TestIsEurekaModule_MgrPrefix(t *testing.T) {
 }
 
 func TestIsEurekaModule_ExactMatches(t *testing.T) {
+	testhelpers.SetTempHome(t)
+
 	mockHTTP := &testhelpers.MockHTTPClient{}
 	mockAWS := &MockAWSSvc{}
 	act := testhelpers.NewMockAction()
@@ -528,6 +541,8 @@ func TestIsEurekaModule_ExactMatches(t *testing.T) {
 }
 
 func TestIsEurekaModule_RegularFolioModuleNotEureka(t *testing.T) {
+	testhelpers.SetTempHome(t)
+
 	mockHTTP := &testhelpers.MockHTTPClient{}
 	mockAWS := &MockAWSSvc{}
 	act := testhelpers.NewMockAction()
@@ -836,6 +851,8 @@ func modulesFilePath(t *testing.T) string {
 }
 
 func TestGetModules_SkipRegistry_ReadsLocalFile(t *testing.T) {
+	testhelpers.SetTempHome(t)
+
 	filePath := modulesFilePath(t)
 
 	known := []models.ApplicationModule{
@@ -863,6 +880,8 @@ func TestGetModules_SkipRegistry_ReadsLocalFile(t *testing.T) {
 }
 
 func TestGetModules_SkipRegistry_MissingFile(t *testing.T) {
+	testhelpers.SetTempHome(t)
+
 	filePath := modulesFilePath(t)
 
 	// Temporarily move the file aside if it exists so we get a clean miss
@@ -887,6 +906,8 @@ func TestGetModules_SkipRegistry_MissingFile(t *testing.T) {
 }
 
 func TestGetModules_FetchAndPersistWritesFile(t *testing.T) {
+	testhelpers.SetTempHome(t)
+
 	filePath := modulesFilePath(t)
 	t.Cleanup(func() { _ = os.Remove(filePath) })
 
@@ -921,6 +942,8 @@ func TestGetModules_FetchAndPersistWritesFile(t *testing.T) {
 }
 
 func TestGetModules_PreferLocalWhenFileExists(t *testing.T) {
+	testhelpers.SetTempHome(t)
+
 	filePath := modulesFilePath(t)
 
 	known := []models.ApplicationModule{

--- a/eureka-cli/registrysvc/registry_svc_test.go
+++ b/eureka-cli/registrysvc/registry_svc_test.go
@@ -16,6 +16,19 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// TestMain redirects the user home directory to a temporary directory so tests never touch the real ~/.eureka
+func TestMain(m *testing.M) {
+	tempHome, err := os.MkdirTemp("", "eureka-test-home")
+	if err != nil {
+		panic(err)
+	}
+	_ = os.Setenv("HOME", tempHome)
+	_ = os.Setenv("USERPROFILE", tempHome)
+	code := m.Run()
+	_ = os.RemoveAll(tempHome)
+	os.Exit(code)
+}
+
 // MockAWSSvc is a mock for awssvc.AWSProcessor
 type MockAWSSvc struct {
 	mock.Mock


### PR DESCRIPTION
## Purpose

`GetHomeDirPath` creates the `~/.eureka` config directory with mode `0644`, which lacks the execute bit required to enter a directory. On a fresh machine where `~/.eureka` does not yet exist, the CLI creates a directory it cannot traverse, so subsequent reads and writes of config files fail with permission denied. This is masked in CI by a workflow step that pre-creates the directory and locally by pre-existing directories. The mode also leaves the directory group- and world-readable, which is inappropriate for a directory holding deployment configuration.

## Approach

- Change the `os.MkdirAll` mode in `helpers/io_helper.go` from `0644` to `0700` so the directory is traversable and restricted to the owner, matching the permissions CI already applies.
- Redirect `HOME`/`USERPROFILE` to a temporary directory in the `helpers`, `moduleprops`, and `registrysvc` tests, so tests never create or touch the real `~/.eureka`.
- Extend the `GetHomeDirPath` test to assert the resolved path and the `0700` directory mode, guarding the permissions fix.

## Review feedback addressed

- Route log directory creation in `cmd/root.go` through `helpers.GetHomeDirPath`.
- Define the permission once as `constant.DirPerm` (`0700`) and use it at every directory-creation site under `~/.eureka`, including `CopyMultipleFiles`.
- Repair existing installations: `GetHomeDirPath` now also applies `os.Chmod`. Directories created by older releases with `0644` or `0755` are healed on the next run.
- Extract the temporary-home setup into `testhelpers.SetTempHome` and apply it across the `helpers`, `moduleprops`, `registrysvc`, `gitclient`, `gitrepository` and `cmd` tests. The `registrysvc` `TestMain` was replaced by per-test isolation, and the `gitrepository` tests moved to an external test package to avoid an import cycle with `testhelpers`.
- Remove the workflow steps that pre-created `~/.eureka`, so CI itself verifies the CLI works on a fresh machine.
