### PR TITLE
[ECLI-31] Ignore missing system-user token on mod-users-keycloak sidecar egress

### DIFF
--- a/eureka-cli/config.combined-native-otel.yaml
+++ b/eureka-cli/config.combined-native-otel.yaml
@@ -181,6 +181,8 @@ backend-modules:
     use-vault: true
     use-okapi-url: true
     disable-system-user: true
+    sidecar-environment:
+      HANDLER_EGRESS_IGNORE_SYSTEM_USER_TOKEN_ERROR: "true" # no system user - see ECLI-31
     port: 9904
     environment:
       SINGLE_TENANT_UX: "false"

--- a/eureka-cli/config.combined-native.yaml
+++ b/eureka-cli/config.combined-native.yaml
@@ -171,6 +171,8 @@ backend-modules:
     use-vault: true
     use-okapi-url: true
     disable-system-user: true
+    sidecar-environment:
+      HANDLER_EGRESS_IGNORE_SYSTEM_USER_TOKEN_ERROR: "true" # no system user - see ECLI-31
     port: 9904
     environment:
       SINGLE_TENANT_UX: "false"

--- a/eureka-cli/config.combined.yaml
+++ b/eureka-cli/config.combined.yaml
@@ -167,6 +167,8 @@ backend-modules:
     use-vault: true
     use-okapi-url: true
     disable-system-user: true
+    sidecar-environment:
+      HANDLER_EGRESS_IGNORE_SYSTEM_USER_TOKEN_ERROR: "true" # no system user - see ECLI-31
     port: 9904
     environment:
       SINGLE_TENANT_UX: "false"

--- a/eureka-cli/config.ecs-migration.yaml
+++ b/eureka-cli/config.ecs-migration.yaml
@@ -5600,6 +5600,8 @@ backend-modules:
     use-vault: true
     use-okapi-url: true
     disable-system-user: true
+    sidecar-environment:
+      HANDLER_EGRESS_IGNORE_SYSTEM_USER_TOKEN_ERROR: "true" # no system user - see ECLI-31
     port: 9904
     environment:
       SINGLE_TENANT_UX: "true"

--- a/eureka-cli/config.ecs-single.yaml
+++ b/eureka-cli/config.ecs-single.yaml
@@ -221,6 +221,8 @@ backend-modules:
     use-vault: true
     use-okapi-url: true
     disable-system-user: true
+    sidecar-environment:
+      HANDLER_EGRESS_IGNORE_SYSTEM_USER_TOKEN_ERROR: "true" # no system user - see ECLI-31
     port: 9904
     environment:
       SINGLE_TENANT_UX: "true"

--- a/eureka-cli/config.ecs.yaml
+++ b/eureka-cli/config.ecs.yaml
@@ -236,6 +236,8 @@ backend-modules:
     use-vault: true
     use-okapi-url: true
     disable-system-user: true
+    sidecar-environment:
+      HANDLER_EGRESS_IGNORE_SYSTEM_USER_TOKEN_ERROR: "true" # no system user - see ECLI-31
     port: 9904
     environment:
       SINGLE_TENANT_UX: "true"

--- a/eureka-cli/config.import.yaml
+++ b/eureka-cli/config.import.yaml
@@ -184,6 +184,8 @@ backend-modules:
     use-vault: true
     use-okapi-url: true
     disable-system-user: true
+    sidecar-environment:
+      HANDLER_EGRESS_IGNORE_SYSTEM_USER_TOKEN_ERROR: "true" # no system user - see ECLI-31
     port: 9904
     environment:
       SINGLE_TENANT_UX: "false"


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/ECLI-31
See also https://github.com/folio-org/folio-module-sidecar/pull/383

## Purpose

`deployApplication` fails at tenant entitlement: `mod-users-keycloak`'s `/_/tenant` returns `400 "System user token is required..."` and the flow is cancelled. `mod-users-keycloak` has no system user, so its sidecar egress calls during tenant install carry no `X-Okapi-Token`. `folio-module-sidecar` now defaults `handler.egress.ignore-system-user-token-error` to `false`, which rejects those calls.

## Approach

Set `HANDLER_EGRESS_IGNORE_SYSTEM_USER_TOKEN_ERROR: "true"` in the `sidecar-environment` of `mod-users-keycloak` in every profile that defines it. Scope is limited to `mod-users-keycloak`. Other affected modules are fixed module-side, not via this flag.
