### PR TITLE
[ECLI-33] Bump Go to 1.26.5 to pick up security fixes and stay on a supported release line

### DIFF
--- a/.github/actions/setup-go/action.yml
+++ b/.github/actions/setup-go/action.yml
@@ -6,7 +6,7 @@ inputs:
   go-version:
     description: 'Go version to install'
     required: false
-    default: '1.25.3'
+    default: '1.26.5'
   cache-dependency-path:
     description: 'Path to go.sum file for cache dependency'
     required: false

--- a/eureka-cli/go.mod
+++ b/eureka-cli/go.mod
@@ -1,6 +1,6 @@
 module github.com/folio-org/eureka-setup/eureka-cli
 
-go 1.25.3
+go 1.26.5
 
 require (
 	github.com/Masterminds/semver/v3 v3.5.0


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/ECLI-33

## Purpose

The module currently builds with Go 1.25.3, whose standard library has reachable vulnerabilities in `net/http`, `crypto/tls`, and `crypto/x509` (15 `govulncheck` findings via `httpclient`). The 1.25 line also loses support once Go 1.27 ships (~August 2026). Go 1.26.5 is the newest patch release on the current stable line, so bumping directly to it clears the stdlib advisories and moves off 1.25 before its support window closes.

## Approach

- Raise the `go` directive in `eureka-cli/go.mod` from 1.25.3 to 1.26.5.
- Update the default `go-version` in the shared `.github/actions/setup-go` composite action to 1.26.5 so CI uses the same toolchain.