### PR TITLE
[ECLI-27] Separate ~/.eureka path resolution from directory creation

### DIFF
--- a/.github/workflows/build-and-run-cli.yml
+++ b/.github/workflows/build-and-run-cli.yml
@@ -55,7 +55,7 @@ jobs:
     name: Go Test
     runs-on: ubuntu-latest
     env:
-      EXCLUDE_PATTERN: '/(cmd|interceptmodulesvc|upgrademodulesvc)$|/internal/|eureka-cli$'
+      EXCLUDE_PATTERN: '/(interceptmodulesvc|upgrademodulesvc)$|/internal/|eureka-cli$'
     steps:
       - name: Checkout code
         uses: actions/checkout@v6.0.2

--- a/eureka-cli/README.md
+++ b/eureka-cli/README.md
@@ -67,7 +67,7 @@
 
 Install dependencies:
 
-- [Go](https://go.dev/doc/install) compiler: last development-tested version is `go1.25.3 windows/amd64`
+- [Go](https://go.dev/doc/install) compiler: last development-tested version is `go1.26.5 linux/amd64`
 - [Rancher Desktop](https://rancherdesktop.io/) container daemon: last development-tested version is `v1.20.1`
   - Enable **dockerd (Moby)** container engine
   - Disable **Check for updates automatically**

--- a/eureka-cli/cmd/cmd_test.go
+++ b/eureka-cli/cmd/cmd_test.go
@@ -6,9 +6,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"sync"
 	"testing"
 
@@ -1747,14 +1749,8 @@ func TestAttachCapabilitySets_Success(t *testing.T) {
 	mockKafkaSvc := &MockKafkaSvc{}
 	run.Config.KafkaSvc = mockKafkaSvc
 
-	testhelpers.SetTempHome(t)
-
-	homeDir, err := os.UserHomeDir()
-	if err != nil {
-		t.Fatal(err)
-	}
-	filePath := filepath.Join(homeDir, ".eureka", fmt.Sprintf(constant.CapabilitySetsFilePattern, "test-tenant"))
-	t.Cleanup(func() { _ = os.Remove(filePath) })
+	homeDir := testhelpers.SetTempConfigDir(t)
+	filePath := filepath.Join(homeDir, fmt.Sprintf(constant.CapabilitySetsFilePattern, "test-tenant"))
 
 	mockDocker.On("Create").Return(nil, nil)
 	mockModule.On("GetVaultRootToken", mock.Anything).Return("", nil)
@@ -1768,7 +1764,7 @@ func TestAttachCapabilitySets_Success(t *testing.T) {
 	mockKeycloak.On("CountCapabilitySets", "test-tenant").Return(530, nil)
 
 	// Act
-	err = run.AttachCapabilitySets(constant.NoneConsortium, constant.Default, 0, false)
+	err := run.AttachCapabilitySets(constant.NoneConsortium, constant.Default, 0, false)
 
 	// Assert
 	assert.NoError(t, err)
@@ -1786,20 +1782,10 @@ func TestAttachCapabilitySets_Success(t *testing.T) {
 
 func TestAttachCapabilitySets_FilePersisted_SkipsPoll(t *testing.T) {
 	// Arrange — pre-create persistence file; live count matches → skip poll
-	testhelpers.SetTempHome(t)
-
-	homeDir, err := os.UserHomeDir()
-	if err != nil {
-		t.Fatal(err)
-	}
-	filePath := filepath.Join(homeDir, ".eureka", fmt.Sprintf(constant.CapabilitySetsFilePattern, "test-tenant"))
-	if err := os.MkdirAll(filepath.Dir(filePath), constant.DirPerm); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filePath, []byte(`{"tenant":"test-tenant","total":530}`), 0644); err != nil {
-		t.Fatal(err)
-	}
-	t.Cleanup(func() { _ = os.Remove(filePath) })
+	homeDir := testhelpers.SetTempConfigDir(t)
+	fileName := fmt.Sprintf(constant.CapabilitySetsFilePattern, "test-tenant")
+	filePath := filepath.Join(homeDir, fileName)
+	testhelpers.CreateFileInDir(t, homeDir, fileName, `{"tenant":"test-tenant","total":530}`)
 
 	run, mockManagement, mockKeycloak, _, mockDocker, mockModule := newTestRun(action.AttachCapabilitySets)
 	mockKafkaSvc := &MockKafkaSvc{}
@@ -1816,7 +1802,7 @@ func TestAttachCapabilitySets_FilePersisted_SkipsPoll(t *testing.T) {
 	mockKeycloak.On("CountCapabilitySets", "test-tenant").Return(530, nil)
 
 	// Act
-	err = run.AttachCapabilitySets(constant.NoneConsortium, constant.Default, 0, false)
+	err := run.AttachCapabilitySets(constant.NoneConsortium, constant.Default, 0, false)
 
 	// Assert
 	assert.NoError(t, err)
@@ -1901,20 +1887,10 @@ func TestAttachCapabilitySets_AttachError(t *testing.T) {
 
 func TestAttachCapabilitySets_ForceRefresh_DeletesFile(t *testing.T) {
 	// Arrange — pre-create file; forceRefresh=true deletes it, forcing a full poll
-	testhelpers.SetTempHome(t)
-
-	homeDir, err := os.UserHomeDir()
-	if err != nil {
-		t.Fatal(err)
-	}
-	filePath := filepath.Join(homeDir, ".eureka", fmt.Sprintf(constant.CapabilitySetsFilePattern, "test-tenant"))
-	if err := os.MkdirAll(filepath.Dir(filePath), constant.DirPerm); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filePath, []byte(`{"tenant":"test-tenant","total":200}`), 0644); err != nil {
-		t.Fatal(err)
-	}
-	t.Cleanup(func() { _ = os.Remove(filePath) })
+	homeDir := testhelpers.SetTempConfigDir(t)
+	fileName := fmt.Sprintf(constant.CapabilitySetsFilePattern, "test-tenant")
+	filePath := filepath.Join(homeDir, fileName)
+	testhelpers.CreateFileInDir(t, homeDir, fileName, `{"tenant":"test-tenant","total":200}`)
 
 	run, mockManagement, mockKeycloak, _, mockDocker, mockModule := newTestRun(action.AttachCapabilitySets)
 	mockKafkaSvc := &MockKafkaSvc{}
@@ -1932,7 +1908,7 @@ func TestAttachCapabilitySets_ForceRefresh_DeletesFile(t *testing.T) {
 	mockKeycloak.On("CountCapabilitySets", "test-tenant").Return(200, nil)
 
 	// Act
-	err = run.AttachCapabilitySets(constant.NoneConsortium, constant.Default, 0, true)
+	err := run.AttachCapabilitySets(constant.NoneConsortium, constant.Default, 0, true)
 
 	// Assert — poll must have been called since file was deleted
 	assert.NoError(t, err)
@@ -1949,20 +1925,10 @@ func TestAttachCapabilitySets_ForceRefresh_DeletesFile(t *testing.T) {
 
 func TestAttachCapabilitySets_CountChanged_Polls(t *testing.T) {
 	// Arrange — persisted total doesn't match live count; poll is required
-	testhelpers.SetTempHome(t)
-
-	homeDir, err := os.UserHomeDir()
-	if err != nil {
-		t.Fatal(err)
-	}
-	filePath := filepath.Join(homeDir, ".eureka", fmt.Sprintf(constant.CapabilitySetsFilePattern, "test-tenant"))
-	if err := os.MkdirAll(filepath.Dir(filePath), constant.DirPerm); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filePath, []byte(`{"tenant":"test-tenant","total":100}`), 0644); err != nil {
-		t.Fatal(err)
-	}
-	t.Cleanup(func() { _ = os.Remove(filePath) })
+	homeDir := testhelpers.SetTempConfigDir(t)
+	fileName := fmt.Sprintf(constant.CapabilitySetsFilePattern, "test-tenant")
+	filePath := filepath.Join(homeDir, fileName)
+	testhelpers.CreateFileInDir(t, homeDir, fileName, `{"tenant":"test-tenant","total":100}`)
 
 	run, mockManagement, mockKeycloak, _, mockDocker, mockModule := newTestRun(action.AttachCapabilitySets)
 	mockKafkaSvc := &MockKafkaSvc{}
@@ -1981,7 +1947,7 @@ func TestAttachCapabilitySets_CountChanged_Polls(t *testing.T) {
 	mockKeycloak.On("CountCapabilitySets", "test-tenant").Return(200, nil)
 
 	// Act
-	err = run.AttachCapabilitySets(constant.NoneConsortium, constant.Default, 0, false)
+	err := run.AttachCapabilitySets(constant.NoneConsortium, constant.Default, 0, false)
 
 	// Assert — poll called; file updated to live count
 	assert.NoError(t, err)
@@ -1998,20 +1964,8 @@ func TestAttachCapabilitySets_CountChanged_Polls(t *testing.T) {
 
 func TestAttachCapabilitySets_PreCheckCountError_Polls(t *testing.T) {
 	// Arrange — CountCapabilitySets errors during pre-check; falls through to poll
-	testhelpers.SetTempHome(t)
-
-	homeDir, err := os.UserHomeDir()
-	if err != nil {
-		t.Fatal(err)
-	}
-	filePath := filepath.Join(homeDir, ".eureka", fmt.Sprintf(constant.CapabilitySetsFilePattern, "test-tenant"))
-	if err := os.MkdirAll(filepath.Dir(filePath), constant.DirPerm); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filePath, []byte(`{"tenant":"test-tenant","total":300}`), 0644); err != nil {
-		t.Fatal(err)
-	}
-	t.Cleanup(func() { _ = os.Remove(filePath) })
+	homeDir := testhelpers.SetTempConfigDir(t)
+	testhelpers.CreateFileInDir(t, homeDir, fmt.Sprintf(constant.CapabilitySetsFilePattern, "test-tenant"), `{"tenant":"test-tenant","total":300}`)
 
 	run, mockManagement, mockKeycloak, _, mockDocker, mockModule := newTestRun(action.AttachCapabilitySets)
 	mockKafkaSvc := &MockKafkaSvc{}
@@ -2030,7 +1984,7 @@ func TestAttachCapabilitySets_PreCheckCountError_Polls(t *testing.T) {
 	mockKeycloak.On("CountCapabilitySets", "test-tenant").Return(300, nil)
 
 	// Act
-	err = run.AttachCapabilitySets(constant.NoneConsortium, constant.Default, 0, false)
+	err := run.AttachCapabilitySets(constant.NoneConsortium, constant.Default, 0, false)
 
 	// Assert — poll called despite file existing; function succeeds
 	assert.NoError(t, err)
@@ -2044,14 +1998,8 @@ func TestAttachCapabilitySets_PostAttachCountError_ReturnsNil(t *testing.T) {
 	mockKafkaSvc := &MockKafkaSvc{}
 	run.Config.KafkaSvc = mockKafkaSvc
 
-	testhelpers.SetTempHome(t)
-
-	homeDir, err := os.UserHomeDir()
-	if err != nil {
-		t.Fatal(err)
-	}
-	filePath := filepath.Join(homeDir, ".eureka", fmt.Sprintf(constant.CapabilitySetsFilePattern, "test-tenant"))
-	t.Cleanup(func() { _ = os.Remove(filePath) })
+	homeDir := testhelpers.SetTempConfigDir(t)
+	filePath := filepath.Join(homeDir, fmt.Sprintf(constant.CapabilitySetsFilePattern, "test-tenant"))
 
 	mockDocker.On("Create").Return(nil, nil)
 	mockModule.On("GetVaultRootToken", mock.Anything).Return("", nil)
@@ -2065,7 +2013,7 @@ func TestAttachCapabilitySets_PostAttachCountError_ReturnsNil(t *testing.T) {
 	mockKeycloak.On("CountCapabilitySets", "test-tenant").Return(0, assert.AnError)
 
 	// Act
-	err = run.AttachCapabilitySets(constant.NoneConsortium, constant.Default, 0, false)
+	err := run.AttachCapabilitySets(constant.NoneConsortium, constant.Default, 0, false)
 
 	// Assert — count error is non-fatal; no file written
 	assert.NoError(t, err)
@@ -2932,4 +2880,33 @@ func TestInterceptModule_InterceptError(t *testing.T) {
 	// Assert
 	assert.Error(t, err)
 	assert.Equal(t, expectedError, err)
+}
+
+// ==================== Home Directory Tests ====================
+
+func TestInitConfig_RepairsHomeDirPermissionsOfOlderInstallations(t *testing.T) {
+	// Arrange
+	tempHome := testhelpers.SetTempHome(t)
+	homeDir := filepath.Join(tempHome, constant.ConfigDir)
+	assert.NoError(t, os.Mkdir(homeDir, 0755))
+	// A readable config keeps initConfig from reaching copyHomeDirFiles, which needs the embedded file system
+	testhelpers.CreateFileInDir(t, homeDir, "config.combined.yaml", "profile:\n  name: combined\n")
+
+	previousParams, previousLogger, previousDefault := params, logger, slog.Default()
+	t.Cleanup(func() {
+		params, logger = previousParams, previousLogger
+		slog.SetDefault(previousDefault)
+	})
+	viper.Reset()
+	t.Cleanup(viper.Reset)
+	params = action.Param{Profile: constant.CombinedProfile}
+
+	// Act
+	initConfig()
+
+	// Assert
+	info, err := os.Stat(homeDir)
+	if assert.NoError(t, err) && runtime.GOOS != "windows" {
+		assert.Equal(t, constant.DirPerm, info.Mode().Perm())
+	}
 }

--- a/eureka-cli/cmd/root.go
+++ b/eureka-cli/cmd/root.go
@@ -54,30 +54,28 @@ func Execute(fs *embed.FS) {
 }
 
 func initConfig() {
-	setConfig(&params)
+	homeDir, err := helpers.EnsureHomeDir()
+	cobra.CheckErr(err)
+
+	setConfig(&params, homeDir)
 	viper.AutomaticEnv()
 
 	if params.OverwriteFiles {
-		createHomeDir(true)
-	} else {
-		if err := viper.ReadInConfig(); err != nil {
-			createHomeDir(false)
-		}
+		copyHomeDirFiles(homeDir, true)
+	} else if readErr := viper.ReadInConfig(); readErr != nil {
+		copyHomeDirFiles(homeDir, false)
 	}
 
-	err := viper.ReadInConfig()
+	err = viper.ReadInConfig()
 	cobra.CheckErr(err)
 
-	logger, err = setDefaultLogger()
+	logger, err = setDefaultLogger(homeDir)
 	cobra.CheckErr(err)
 }
 
-func setConfig(params *action.Param) {
+func setConfig(params *action.Param, homeDir string) {
 	if params.ConfigFile == "" {
-		home, err := os.UserHomeDir()
-		cobra.CheckErr(err)
-
-		viper.AddConfigPath(filepath.Join(home, constant.ConfigDir))
+		viper.AddConfigPath(homeDir)
 		viper.SetConfigType(constant.ConfigType)
 		if params.Profile == "" {
 			params.Profile = constant.GetDefaultProfile()
@@ -91,15 +89,10 @@ func setConfig(params *action.Param) {
 	}
 }
 
-func setDefaultLogger() (*slog.Logger, error) {
+func setDefaultLogger(homeDir string) (*slog.Logger, error) {
 	logLevel := slog.LevelInfo
 	if params.EnableDebug {
 		logLevel = slog.LevelDebug
-	}
-
-	homeDir, err := helpers.GetHomeDirPath()
-	if err != nil {
-		return nil, err
 	}
 
 	logDir := filepath.Join(homeDir, constant.LogDir)
@@ -128,10 +121,7 @@ func setDefaultLogger() (*slog.Logger, error) {
 	return logger, nil
 }
 
-func createHomeDir(overwriteFiles bool) {
-	homeDir, err := helpers.GetHomeDirPath()
-	cobra.CheckErr(err)
-
+func copyHomeDirFiles(homeDir string, overwriteFiles bool) {
 	if slog.Default().Enabled(context.Background(), slog.LevelDebug) {
 		if overwriteFiles {
 			fmt.Printf("Overwriting files in %s home directory\n\n", homeDir)
@@ -139,7 +129,7 @@ func createHomeDir(overwriteFiles bool) {
 			fmt.Printf("Creating missing files in %s home directory\n\n", homeDir)
 		}
 	}
-	err = helpers.CopyMultipleFiles(homeDir, runFs)
+	err := helpers.CopyMultipleFiles(homeDir, runFs)
 	cobra.CheckErr(err)
 
 	if slog.Default().Enabled(context.Background(), slog.LevelDebug) {

--- a/eureka-cli/helpers/io_helper.go
+++ b/eureka-cli/helpers/io_helper.go
@@ -151,13 +151,21 @@ func GetHomeDirPath() (string, error) {
 		return "", err
 	}
 
-	homeDir := filepath.Join(userHome, constant.ConfigDir)
-	if err = os.MkdirAll(homeDir, constant.DirPerm); err != nil {
+	return filepath.Join(userHome, constant.ConfigDir), nil
+}
+
+func EnsureHomeDir() (string, error) {
+	homeDir, err := GetHomeDirPath()
+	if err != nil {
+		return "", err
+	}
+
+	if err := os.MkdirAll(homeDir, constant.DirPerm); err != nil {
 		return "", err
 	}
 
 	// MkdirAll does not change the mode of an existing directory, so repair installations created by older releases with wrong permissions
-	if err = os.Chmod(homeDir, constant.DirPerm); err != nil {
+	if err := os.Chmod(homeDir, constant.DirPerm); err != nil {
 		return "", err
 	}
 

--- a/eureka-cli/helpers/io_helper_test.go
+++ b/eureka-cli/helpers/io_helper_test.go
@@ -386,12 +386,26 @@ func TestGetCurrentWorkDirPath_Success(t *testing.T) {
 	assert.NotEmpty(t, result)
 }
 
-func TestGetHomeDirPath_CreatesDirectoryWithOwnerOnlyPermissions(t *testing.T) {
+func TestGetHomeDirPath_ResolvesPathWithoutCreatingDirectory(t *testing.T) {
+	// Arrange
+	tempHome := testhelpers.SetTempHome(t)
+	homeDir := filepath.Join(tempHome, ".eureka")
+
+	// Act
+	result, err := helpers.GetHomeDirPath()
+
+	// Assert
+	assert.NoError(t, err)
+	assert.Equal(t, homeDir, result)
+	assert.NoDirExists(t, homeDir)
+}
+
+func TestEnsureHomeDir_CreatesDirectoryWithOwnerOnlyPermissions(t *testing.T) {
 	// Arrange
 	tempHome := testhelpers.SetTempHome(t)
 
 	// Act
-	result, err := helpers.GetHomeDirPath()
+	result, err := helpers.EnsureHomeDir()
 
 	// Assert
 	assert.NoError(t, err)
@@ -407,14 +421,14 @@ func TestGetHomeDirPath_CreatesDirectoryWithOwnerOnlyPermissions(t *testing.T) {
 	}
 }
 
-func TestGetHomeDirPath_RepairsExistingDirectoryPermissions(t *testing.T) {
+func TestEnsureHomeDir_RepairsExistingDirectoryPermissions(t *testing.T) {
 	// Arrange
 	tempHome := testhelpers.SetTempHome(t)
 	homeDir := filepath.Join(tempHome, ".eureka")
 	assert.NoError(t, os.Mkdir(homeDir, 0644))
 
 	// Act
-	result, err := helpers.GetHomeDirPath()
+	result, err := helpers.EnsureHomeDir()
 
 	// Assert
 	assert.NoError(t, err)

--- a/eureka-cli/internal/testhelpers/file_helpers.go
+++ b/eureka-cli/internal/testhelpers/file_helpers.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/folio-org/eureka-setup/eureka-cli/helpers"
 )
 
 // SetTempHome redirects the user home directory to a per-test temporary directory so tests never touch the real ~/.eureka
@@ -16,6 +18,19 @@ func SetTempHome(t *testing.T) string {
 	t.Setenv("USERPROFILE", tempHome)
 
 	return tempHome
+}
+
+// SetTempConfigDir redirects the user home directory like SetTempHome and creates the home config directory, returning its path
+func SetTempConfigDir(t *testing.T) string {
+	t.Helper()
+
+	SetTempHome(t)
+	homeDir, err := helpers.EnsureHomeDir()
+	if err != nil {
+		t.Fatalf("failed to create the home config directory: %v", err)
+	}
+
+	return homeDir
 }
 
 // CreateTempJSONFile creates a temporary JSON file with the given data

--- a/eureka-cli/registrysvc/registry_svc_test.go
+++ b/eureka-cli/registrysvc/registry_svc_test.go
@@ -181,7 +181,7 @@ func stubFARWithUI(mockHTTP *testhelpers.MockHTTPClient, farBase string, appName
 }
 
 func TestGetModules_Success(t *testing.T) {
-	testhelpers.SetTempHome(t)
+	testhelpers.SetTempConfigDir(t)
 
 	mockHTTP := &testhelpers.MockHTTPClient{}
 	mockAWS := &MockAWSSvc{}
@@ -210,7 +210,7 @@ func TestGetModules_Success(t *testing.T) {
 }
 
 func TestGetModules_Verbose(t *testing.T) {
-	testhelpers.SetTempHome(t)
+	testhelpers.SetTempConfigDir(t)
 
 	mockHTTP := &testhelpers.MockHTTPClient{}
 	mockAWS := &MockAWSSvc{}
@@ -236,7 +236,7 @@ func TestGetModules_Verbose(t *testing.T) {
 }
 
 func TestGetModules_LSPFetchError(t *testing.T) {
-	testhelpers.SetTempHome(t)
+	testhelpers.SetTempConfigDir(t)
 
 	mockHTTP := &testhelpers.MockHTTPClient{}
 	mockAWS := &MockAWSSvc{}
@@ -257,7 +257,7 @@ func TestGetModules_LSPFetchError(t *testing.T) {
 }
 
 func TestGetModules_FARFetchError(t *testing.T) {
-	testhelpers.SetTempHome(t)
+	testhelpers.SetTempConfigDir(t)
 
 	mockHTTP := &testhelpers.MockHTTPClient{}
 	mockAWS := &MockAWSSvc{}
@@ -285,7 +285,7 @@ func TestGetModules_FARFetchError(t *testing.T) {
 }
 
 func TestGetModules_EurekaComponentsIncluded(t *testing.T) {
-	testhelpers.SetTempHome(t)
+	testhelpers.SetTempConfigDir(t)
 
 	mockHTTP := &testhelpers.MockHTTPClient{}
 	mockAWS := &MockAWSSvc{}
@@ -309,7 +309,7 @@ func TestGetModules_EurekaComponentsIncluded(t *testing.T) {
 }
 
 func TestGetModules_ModulePartitioning(t *testing.T) {
-	testhelpers.SetTempHome(t)
+	testhelpers.SetTempConfigDir(t)
 
 	mockHTTP := &testhelpers.MockHTTPClient{}
 	mockAWS := &MockAWSSvc{}
@@ -342,7 +342,7 @@ func TestGetModules_ModulePartitioning(t *testing.T) {
 }
 
 func TestGetModules_RequiredAndOptionalMerged(t *testing.T) {
-	testhelpers.SetTempHome(t)
+	testhelpers.SetTempConfigDir(t)
 
 	mockHTTP := &testhelpers.MockHTTPClient{}
 	mockAWS := &MockAWSSvc{}
@@ -372,7 +372,7 @@ func TestGetModules_RequiredAndOptionalMerged(t *testing.T) {
 }
 
 func TestGetModules_ExperimentalAppsIncluded(t *testing.T) {
-	testhelpers.SetTempHome(t)
+	testhelpers.SetTempConfigDir(t)
 
 	mockHTTP := &testhelpers.MockHTTPClient{}
 	mockAWS := &MockAWSSvc{}
@@ -405,7 +405,7 @@ func TestGetModules_ExperimentalAppsIncluded(t *testing.T) {
 }
 
 func TestGetModules_UIModulesIncluded(t *testing.T) {
-	testhelpers.SetTempHome(t)
+	testhelpers.SetTempConfigDir(t)
 
 	mockHTTP := &testhelpers.MockHTTPClient{}
 	mockAWS := &MockAWSSvc{}
@@ -438,7 +438,7 @@ func TestGetModules_UIModulesIncluded(t *testing.T) {
 }
 
 func TestGetModules_EmptyApplications(t *testing.T) {
-	testhelpers.SetTempHome(t)
+	testhelpers.SetTempConfigDir(t)
 
 	mockHTTP := &testhelpers.MockHTTPClient{}
 	mockAWS := &MockAWSSvc{}
@@ -463,7 +463,7 @@ func TestGetModules_EmptyApplications(t *testing.T) {
 // ==================== isEurekaModule Tests ====================
 
 func TestIsEurekaModule_KeycloakSuffix(t *testing.T) {
-	testhelpers.SetTempHome(t)
+	testhelpers.SetTempConfigDir(t)
 
 	mockHTTP := &testhelpers.MockHTTPClient{}
 	mockAWS := &MockAWSSvc{}
@@ -488,7 +488,7 @@ func TestIsEurekaModule_KeycloakSuffix(t *testing.T) {
 }
 
 func TestIsEurekaModule_MgrPrefix(t *testing.T) {
-	testhelpers.SetTempHome(t)
+	testhelpers.SetTempConfigDir(t)
 
 	mockHTTP := &testhelpers.MockHTTPClient{}
 	mockAWS := &MockAWSSvc{}
@@ -514,7 +514,7 @@ func TestIsEurekaModule_MgrPrefix(t *testing.T) {
 }
 
 func TestIsEurekaModule_ExactMatches(t *testing.T) {
-	testhelpers.SetTempHome(t)
+	testhelpers.SetTempConfigDir(t)
 
 	mockHTTP := &testhelpers.MockHTTPClient{}
 	mockAWS := &MockAWSSvc{}
@@ -541,7 +541,7 @@ func TestIsEurekaModule_ExactMatches(t *testing.T) {
 }
 
 func TestIsEurekaModule_RegularFolioModuleNotEureka(t *testing.T) {
-	testhelpers.SetTempHome(t)
+	testhelpers.SetTempConfigDir(t)
 
 	mockHTTP := &testhelpers.MockHTTPClient{}
 	mockAWS := &MockAWSSvc{}
@@ -851,7 +851,7 @@ func modulesFilePath(t *testing.T) string {
 }
 
 func TestGetModules_SkipRegistry_ReadsLocalFile(t *testing.T) {
-	testhelpers.SetTempHome(t)
+	testhelpers.SetTempConfigDir(t)
 
 	filePath := modulesFilePath(t)
 
@@ -880,7 +880,7 @@ func TestGetModules_SkipRegistry_ReadsLocalFile(t *testing.T) {
 }
 
 func TestGetModules_SkipRegistry_MissingFile(t *testing.T) {
-	testhelpers.SetTempHome(t)
+	testhelpers.SetTempConfigDir(t)
 
 	filePath := modulesFilePath(t)
 
@@ -906,7 +906,7 @@ func TestGetModules_SkipRegistry_MissingFile(t *testing.T) {
 }
 
 func TestGetModules_FetchAndPersistWritesFile(t *testing.T) {
-	testhelpers.SetTempHome(t)
+	testhelpers.SetTempConfigDir(t)
 
 	filePath := modulesFilePath(t)
 	t.Cleanup(func() { _ = os.Remove(filePath) })
@@ -942,7 +942,7 @@ func TestGetModules_FetchAndPersistWritesFile(t *testing.T) {
 }
 
 func TestGetModules_PreferLocalWhenFileExists(t *testing.T) {
-	testhelpers.SetTempHome(t)
+	testhelpers.SetTempConfigDir(t)
 
 	filePath := modulesFilePath(t)
 


### PR DESCRIPTION
[ECLI-27](https://folio-org.atlassian.net/browse/ECLI-27)

## Purpose
`GetHomeDir()` previously not only returned the config dir but also created it if it did not exist. This is an unnecessary entanglement. This PR splits this and results in only one call to `EnsureHomeDir()` in `initConfig()`

## Approach

- `GetHomeDirPath` no longer touches the filesystem
- The new `EnsureHomeDir` creates the directory and repairs the permissions of older installations
  - `initConfig` calls it once at startup, every other caller resolves the path without side effects
- Tests arrange the same state with `testhelpers.SetTempEurekaHome`. 
- Also bump the Go version documented in the README to 1.26.5 and change from windows to linux
- Also include cmd for tests again
