### PR TITLE
[ECLI-37] Group Dependabot version updates and cover local composite actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,10 +14,20 @@ updates:
     ignore:
       - dependency-name: "golang.org/x/*"
         update-types: ["version-update:semver-patch"]
+    groups:
+      go-minor-patch:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
 
-  # GitHub Actions workflow dependencies
+  # GitHub Actions workflow dependencies, plus local composite actions
   - package-ecosystem: "github-actions"
-    directory: "/"
+    directories:
+      - "/"
+      - "/.github/actions/*"
     schedule:
       interval: "monthly"
     open-pull-requests-limit: 2
@@ -26,3 +36,11 @@ updates:
     labels:
       - "github-actions"
       - "dependencies"
+    groups:
+      actions-minor-patch:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/ECLI-37

## Purpose

The monthly Dependabot run opens one PR per dependency, forcing sequential merges with rebases in between, and the composite action `.github/actions/setup-go/action.yml` is not scanned at all.

## Approach

Group minor and patch version updates into one PR per ecosystem (`go-minor-patch`, `actions-minor-patch`); major and security updates stay individual. Add `/.github/actions/*` to the scanned `directories` so local composite actions are covered.
