### PR TITLE
[ECLI-38] Fix hadolint 2.15 findings in folio-netcat and folio-vault Dockerfiles

### DIFF
--- a/eureka-cli/misc/folio-netcat/Dockerfile
+++ b/eureka-cli/misc/folio-netcat/Dockerfile
@@ -8,8 +8,8 @@ RUN apk update && apk add --no-cache netcat-openbsd curl wget bind-tools tracero
     adduser -D -u 1000 -G netcat netcat
 
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
-    CMD nc -h > /dev/null 2>&1 || exit 1
+    CMD ["/bin/sh", "-c", "nc -h > /dev/null 2>&1 || exit 1"]
 
-USER netcat
+USER 1000:1000
 
 CMD ["/bin/sh", "-c", "sleep infinity"]

--- a/eureka-cli/misc/folio-vault/Dockerfile
+++ b/eureka-cli/misc/folio-vault/Dockerfile
@@ -4,8 +4,8 @@ FROM hashicorp/vault:$VAULT_VERSION
 
 RUN apk update && apk add --no-cache curl jq coreutils && \
     rm -rf /var/cache/apk/* && \
-    addgroup -S folio && \
-    adduser -S -G folio folio
+    addgroup -S -g 1001 folio && \
+    adduser -S -u 1001 -G folio folio
 
 COPY config /usr/local/bin/folio/config
 COPY scripts /usr/local/bin/folio/scripts
@@ -14,10 +14,10 @@ RUN chmod 500 /usr/local/bin/folio/scripts/* && \
     chmod 400 /usr/local/bin/folio/config/* && \
     chown -R folio:folio /usr/local/bin/folio
 
-USER folio
+USER 1001:1001
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=5s --retries=3 \
-    CMD curl -f http://localhost:8200/v1/sys/health || exit 1
+    CMD ["/bin/sh", "-c", "curl -f http://localhost:8200/v1/sys/health || exit 1"]
 
 ENTRYPOINT [ "/usr/local/bin/folio/scripts/start.sh" ]
 


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/ECLI-38

## Purpose

The Docker Lint CI job validates `eureka-cli/misc/folio-netcat/Dockerfile` and `eureka-cli/misc/folio-vault/Dockerfile` with hadolint. With hadolint 2.15 the linter flags two patterns in these files: `HEALTHCHECK CMD` instructions written in shell form instead of JSON notation, and `USER` instructions that reference a user by name instead of a numeric UID. Named users cannot be verified as non-root by container runtimes, so a numeric UID is required to satisfy the check. This change resolves the findings so the lint job passes, without altering container behavior.

## Approach

- Convert the `HEALTHCHECK CMD` in both Dockerfiles to JSON notation, wrapping the existing command in `/bin/sh -c`
- `folio-netcat`: switch `USER netcat` to `USER 1000:1000`, matching the UID the user is created with
- `folio-vault`: create the `folio` group and user with explicit GID/UID 1001 and switch `USER folio` to `USER 1001:1001`
