### PR TITLE
[ECLI-39] Fix misleading CLI output

### DIFF
--- a/eureka-cli/action/action_gateway.go
+++ b/eureka-cli/action/action_gateway.go
@@ -61,7 +61,7 @@ func getConfigGatewayURL(actionName string) (gatewayURL string, err error) {
 
 func getDefaultGatewayURL(actionName string) (gatewayURL string, err error) {
 	if err = helpers.IsHostnameReachable(actionName, constant.DockerHostname); err != nil {
-		slog.Warn(actionName, "text", "Retrieving default gateway URL was unsuccessful", "error", err)
+		slog.Debug(actionName, "text", "Retrieving default gateway URL was unsuccessful", "error", err)
 		return "", nil
 	}
 

--- a/eureka-cli/cmd/removeUsers.go
+++ b/eureka-cli/cmd/removeUsers.go
@@ -26,8 +26,8 @@ import (
 // removeUsersCmd represents the removeUsers command
 var removeUsersCmd = &cobra.Command{
 	Use:   "removeUsers",
-	Short: "Create users",
-	Long:  `Create all users.`,
+	Short: "Remove users",
+	Long:  `Remove all users.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		run, err := New(action.RemoveUsers)
 		if err != nil {

--- a/eureka-cli/misc/docker-compose.yaml
+++ b/eureka-cli/misc/docker-compose.yaml
@@ -401,7 +401,7 @@ services:
       - 9000:9000
       - 9001:9001
     healthcheck:
-      test: curl -k -f http://127.0.0.1:19001/minio/health/live || exit 1
+      test: curl -k -f http://127.0.0.1:9000/minio/health/live || exit 1
       interval: 30s
       timeout: 10s
       retries: 30


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/ECLI-39

## Purpose

Three small fixes for misleading CLI output: two diagnostics report a problem where none exists, and one help text describes the opposite operation.

## Approach

- Point the `minio` healthcheck at the API port `9000`; it targeted `19001`, a port the container does not listen on, so `minio` always reported `unhealthy`.
- Lower the failed `host.docker.internal` probe log in `getDefaultGatewayURL` from `WARN` to `DEBUG`; the lookup always fails on native Linux Docker and the resolution falls through to the supported `http://172.17.0.1` default.
- Correct the `removeUsers` help text, which said "Create users".
