### PR TITLE
[ECLI-35] Support volume retention across teardown/redeploy cycles (--keepVolumes)

### DIFF
--- a/eureka-cli/README.md
+++ b/eureka-cli/README.md
@@ -210,7 +210,8 @@ Available flags:
 | `--skipModuleDiscovery`   |       | Skip module discovery update                              | upgradeModule                          |
 | `--skipModuleImage`       |       | Skip building module Docker image                         | upgradeModule                          |
 | `--skipRegistry`          |       | Skip retrieving latest registry module versions           | interceptModule, deployApplication,    |
-|                           |       |                                                           | deployManagement, deployModules        |
+|                           |       |                                                           | deployManagement, deployModules,       |
+|                           |       |                                                           | upgradeModule                          |
 | `--skipTenantEntitlement` |       | Skip tenant entitlement operations                        | upgradeModule                          |
 | `--skipUi`                |       | Skip UI build and deployment                              | deployApplication                      |
 | `--tenant`                | `-t`  | Tenant name                                               | getKeycloakAccessToken, getEdgeApiKey, |

--- a/eureka-cli/README.md
+++ b/eureka-cli/README.md
@@ -14,6 +14,7 @@
     - [(Optional) Enable autocompletion](#optional-enable-autocompletion)
     - [Deploy the _combined_ application](#deploy-the-combined-application)
     - [Undeploy the _combined_ application](#undeploy-the-combined-application)
+    - [Preserve data volumes across redeployments](#preserve-data-volumes-across-redeployments)
     - [Deploy the _combined_ application from AWS ECR](#deploy-the-combined-application-from-aws-ecr)
     - [Deploy the _ecs_ application](#deploy-the-ecs-application)
     - [Undeploy the _ecs_ application](#undeploy-the-ecs-application)
@@ -179,6 +180,9 @@ Available flags:
 | `--gatewayURL`            |       | Gateway URL                                               | purgeTenants                           |
 | `--id`                    | `-i`  | Module ID (e.g. mod-orders:13.1.0-SNAPSHOT.1021)          | listModuleVersions                     |
 | `--ids`                   |       | Tenant ids                                                | purgeTenants                           |
+| `--keepVolumes`           | `-k`  | Preserve system data volumes during undeployment          | deployApplication,                     |
+|                           |       |                                                           | undeployApplication,                   |
+|                           |       |                                                           | undeploySystem                         |
 | `--length`                | `-l`  | Salt length for edge API key                              | getEdgeApiKey                          |
 | `--linkedData`            |       | Include Linked Data module in UI bundle                   | buildAndPushUi, deployUi, buildUi      |
 | `--moduleName`            | `-n`  | Module name (e.g. mod-orders)                             | interceptModule, listModules,          |
@@ -275,6 +279,30 @@ eureka-cli buildSystem
 ```bash
 eureka-cli undeployApplication
 ```
+
+> This removes all containers and deletes the system data volumes (PostgreSQL, Vault, Kafka, MinIO, FTP, OpenSearch plugins), so the next deployment starts from scratch and re-runs tenant initialization. To keep the data volumes, add the `--keepVolumes` (`-k`) flag; see [Preserve data volumes across redeployments](#preserve-data-volumes-across-redeployments).
+
+### Preserve data volumes across redeployments
+
+- To keep the system data volumes during teardown for a faster redeployment, add the `--keepVolumes` (`-k`) flag
+
+```bash
+eureka-cli undeployApplication -k
+```
+
+> All containers are removed, but tenants, entitlements, users, roles and other data survive in the preserved volumes. The next `deployApplication` detects the existing state and skips tenant initialization, application creation and entitlement setup, which makes it considerably faster than a cold deployment.
+
+- To restart the whole environment in one command while preserving data, combine `--cleanup` with `-k`
+
+```bash
+eureka-cli deployApplication --cleanup -k
+```
+
+- Scope and caveats:
+  - The flag only has an effect where the system teardown runs: standalone profiles, `undeploySystem`, and `deployApplication --cleanup`. Undeploying a child application (e.g. `-p erm`) never removes the system data volumes, so `-k` is accepted but changes nothing there.
+  - Anonymous container volumes are left behind as orphans when `-k` is used; run `docker volume prune` occasionally to clean them up.
+  - Retained volumes are expected to match the redeployed application version. Retaining volumes across an incompatible version change (e.g. a schema migration) can cause confusing errors on the next deployment; when in doubt, undeploy without `-k` and start clean.
+  - Note that a redeploy re-resolves module versions from the registry, so newer snapshot versions published since the teardown are picked up automatically (already-present images are never re-pulled, but new version tags are). To redeploy exactly the module set that created the retained data, pass `--skipRegistry`.
 
 ### Deploy the _combined_ application from AWS ECR
 

--- a/eureka-cli/action/action_param.go
+++ b/eureka-cli/action/action_param.go
@@ -15,6 +15,7 @@ type Param struct {
 	GatewayHostname       string
 	GatewayURL            string
 	ID                    string
+	KeepVolumes           bool
 	Length                int
 	ModuleName            string
 	ModulePath            string
@@ -76,6 +77,7 @@ var (
 	GatewayHostname       = Flag{"gatewayHostname", "", "Gateway hostname"}
 	GatewayURL            = Flag{"gatewayURL", "", "Gateway URL"}
 	ID                    = Flag{"id", "i", "Module id, e.g. mod-orders:13.1.0-SNAPSHOT.1021"}
+	KeepVolumes           = Flag{"keepVolumes", "k", "Preserve system data volumes during undeployment"}
 	Length                = Flag{"length", "l", "Salt length"}
 	ModuleName            = Flag{"moduleName", "n", "Module name, e.g. mod-orders"}
 	ModulePath            = Flag{"modulePath", "", "Module path, e.g. the path of your module in IntelliJ"}

--- a/eureka-cli/cmd/cmd_test.go
+++ b/eureka-cli/cmd/cmd_test.go
@@ -11,6 +11,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"sync"
 	"testing"
 
@@ -2486,6 +2487,40 @@ func TestUndeploySystem_ExecError(t *testing.T) {
 	// Assert
 	assert.Error(t, err)
 	assert.Equal(t, expectedError, err)
+}
+
+func TestUndeploySystem_VolumeRemoval(t *testing.T) {
+	testCases := []struct {
+		name          string
+		keepVolumes   bool
+		expectVolumes bool
+	}{
+		{name: "removes volumes by default", keepVolumes: false, expectVolumes: true},
+		{name: "keeps volumes with keepVolumes flag", keepVolumes: true, expectVolumes: false},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Arrange
+			run, _, _, _, _, _ := newTestRun(action.UndeploySystem)
+			run.Config.Action.Param.KeepVolumes = tc.keepVolumes
+			mockExecSvc := &MockExecSvc{}
+			run.Config.ExecSvc = mockExecSvc
+
+			mockExecSvc.On("Exec", mock.MatchedBy(func(cmd *exec.Cmd) bool {
+				return slices.Contains(cmd.Args, "down") &&
+					slices.Contains(cmd.Args, "--remove-orphans") &&
+					slices.Contains(cmd.Args, "--volumes") == tc.expectVolumes
+			})).Return(nil)
+
+			// Act
+			err := run.UndeploySystem()
+
+			// Assert
+			assert.NoError(t, err)
+			mockExecSvc.AssertExpectations(t)
+		})
+	}
 }
 
 // ==================== UndeployModules Tests ====================

--- a/eureka-cli/cmd/deployApplication.go
+++ b/eureka-cli/cmd/deployApplication.go
@@ -201,6 +201,7 @@ func init() {
 	deployApplicationCmd.PersistentFlags().BoolVarP(&params.UpdateCloned, action.UpdateCloned.Long, action.UpdateCloned.Short, false, action.UpdateCloned.Description)
 	deployApplicationCmd.PersistentFlags().BoolVarP(&params.OnlyRequired, action.OnlyRequired.Long, action.OnlyRequired.Short, false, action.OnlyRequired.Description)
 	deployApplicationCmd.PersistentFlags().BoolVarP(&params.Cleanup, action.Cleanup.Long, action.Cleanup.Short, false, action.Cleanup.Description)
+	deployApplicationCmd.PersistentFlags().BoolVarP(&params.KeepVolumes, action.KeepVolumes.Long, action.KeepVolumes.Short, false, action.KeepVolumes.Description)
 	deployApplicationCmd.PersistentFlags().BoolVarP(&params.SkipRegistry, action.SkipRegistry.Long, action.SkipRegistry.Short, false, action.SkipRegistry.Description)
 	deployApplicationCmd.PersistentFlags().BoolVarP(&params.SkipUI, action.SkipUI.Long, action.SkipUI.Short, false, action.SkipUI.Description)
 }

--- a/eureka-cli/cmd/undeployApplication.go
+++ b/eureka-cli/cmd/undeployApplication.go
@@ -153,6 +153,7 @@ func (run *Run) UndeployChildApplication() error {
 func init() {
 	rootCmd.AddCommand(undeployApplicationCmd)
 	undeployApplicationCmd.PersistentFlags().StringVarP(&params.ApplicationName, action.ApplicationName.Long, action.ApplicationName.Short, "", action.ApplicationName.Description)
+	undeployApplicationCmd.PersistentFlags().BoolVarP(&params.KeepVolumes, action.KeepVolumes.Long, action.KeepVolumes.Short, false, action.KeepVolumes.Description)
 	undeployApplicationCmd.PersistentFlags().BoolVarP(&params.PurgeSchemas, action.PurgeSchemas.Long, action.PurgeSchemas.Short, false, action.PurgeSchemas.Description)
 	undeployApplicationCmd.PersistentFlags().BoolVarP(&params.SkipCapabilitySets, action.SkipCapabilitySets.Long, action.SkipCapabilitySets.Short, false, action.SkipCapabilitySets.Description)
 }

--- a/eureka-cli/cmd/undeploySystem.go
+++ b/eureka-cli/cmd/undeploySystem.go
@@ -40,10 +40,16 @@ var undeploySystemCmd = &cobra.Command{
 
 func (run *Run) UndeploySystem() error {
 	slog.Info(run.Config.Action.Name, "text", "UNDEPLOYING SYSTEM CONTAINERS")
-	preparedCommand := exec.Command("docker", "compose", "--progress", "plain", "--ansi", "never", "--project-name", "eureka", "down", "--volumes", "--remove-orphans")
-	return run.Config.ExecSvc.Exec(preparedCommand)
+	subCommand := []string{"compose", "--progress", "plain", "--ansi", "never", "--project-name", "eureka", "down"}
+	if !run.Config.Action.Param.KeepVolumes {
+		subCommand = append(subCommand, "--volumes")
+	}
+	subCommand = append(subCommand, "--remove-orphans")
+
+	return run.Config.ExecSvc.Exec(exec.Command("docker", subCommand...))
 }
 
 func init() {
 	rootCmd.AddCommand(undeploySystemCmd)
+	undeploySystemCmd.PersistentFlags().BoolVarP(&params.KeepVolumes, action.KeepVolumes.Long, action.KeepVolumes.Short, false, action.KeepVolumes.Description)
 }


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/ECLI-35

## Purpose

`undeploySystem` - and therefore `undeployApplication` and `deployApplication --cleanup`, which invoke it - always runs `docker compose down --volumes`, wiping the named system data volumes (Postgres with Keycloak and Kong state, Vault, Kafka, MinIO, FTP, OpenSearch plugins) on every teardown. Every redeploy then has to re-run tenant initialization, schema creation, and Keycloak setup from scratch, discarding local state (test data, configured tenants) a developer may want to keep.

This change introduces an opt-in `--keepVolumes` / `-k` flag that preserves the named data volumes across teardown, so a subsequent deploy restarts on the existing storage. Without the flag, teardown behavior is unchanged.

## Approach

- Add the `KeepVolumes` param and `--keepVolumes` / `-k` flag definition in `action/action_param.go`.
- Register the flag on `undeploySystem`, `undeployApplication`, and `deployApplication` (for use with `--cleanup`).
- In `UndeploySystem`, build the `docker compose down` argument list dynamically and omit `--volumes` when the flag is set.
- Add tests in `cmd/cmd_test.go` verifying the compose command with and without the flag.
- Document the flag in a dedicated README section.
- Related docs fix: `--skipRegistry` flag reference table row was missing `upgradeModule`

## Testing

`TestUndeploySystem_VolumeRemoval` asserts the compose teardown includes `--volumes` by default and omits it with the flag. Existing `UndeploySystem` tests cover the unchanged default path.

Manually validated the acceptance criteria and testing scenarios mentioned in the JIRA ticket.