### PR TITLE
ECLI-41: Go 1.26.6 fixing vulns

### DIFF
--- a/.github/actions/setup-go/action.yml
+++ b/.github/actions/setup-go/action.yml
@@ -6,7 +6,7 @@ inputs:
   go-version:
     description: 'Go version to install'
     required: false
-    default: '1.26.5'
+    default: '1.26.6'
   cache-dependency-path:
     description: 'Path to go.sum file for cache dependency'
     required: false

--- a/eureka-cli/README.md
+++ b/eureka-cli/README.md
@@ -68,7 +68,7 @@
 
 Install dependencies:
 
-- [Go](https://go.dev/doc/install) compiler: last development-tested version is `go1.26.5 linux/amd64`
+- [Go](https://go.dev/doc/install) compiler: last development-tested version is `go1.26.6 linux/amd64`
 - [Rancher Desktop](https://rancherdesktop.io/) container daemon: last development-tested version is `v1.20.1`
   - Enable **dockerd (Moby)** container engine
   - Disable **Check for updates automatically**

--- a/eureka-cli/go.mod
+++ b/eureka-cli/go.mod
@@ -1,6 +1,6 @@
 module github.com/folio-org/eureka-setup/eureka-cli
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/Masterminds/semver/v3 v3.5.0


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/ECLI-41


## Purpose

Bump Go from 1.26.5 to 1.26.6 fixing multiple security vulnerabilities: https://github.com/golang/go/issues?q=milestone%3AGo1.26.6+label%3ACherryPickApproved

## Approach

Change the go version in action.yml, go.mod, and README.md
